### PR TITLE
2.0 Release

### DIFF
--- a/Draw/DrawInstance.cs
+++ b/Draw/DrawInstance.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.Remoting.Lifetime;
 using System.Threading.Tasks;
 using OpenTK;
+using OpenTK.Graphics;
 using storyboard.scriptslibrary.maniaModCharts.Draw;
 using storyboard.scriptslibrary.maniaModCharts.effects;
 using StorybrewCommon.Animations;
@@ -32,6 +33,8 @@ namespace StorybrewScripts
         public double fadeOutTime = 10;
         public bool rotateToFaceReceptor = true;
         public double iterationLength = 1000 / 2;
+
+        public Color4 color;
 
         public bool hideHolds = false;
         public bool hideNormalNotes = false;
@@ -107,8 +110,9 @@ namespace StorybrewScripts
             PathWay.DrawPath(this, starttime, endtime, layer, spritePath, type, precision, updatesPerSecond);
         }
 
-        public void drawViaEquation(double duration, EquationFunction noteFunction, bool renderReceptor = true) {
-            ByEquation.drawViaEquation(this, duration, noteFunction, renderReceptor);
+        public string drawViaEquation(double duration, EquationFunction noteFunction, bool renderReceptor = true)
+        {
+            return ByEquation.drawViaEquation(this, duration, noteFunction, renderReceptor);
         }
 
         public List<Vector2> GetPathAnchorVectors(List<Anchor> notePath, double currentTime)
@@ -234,8 +238,8 @@ namespace StorybrewScripts
 
             List<Anchor> notePath = this.notePathByColumn[column];
             Column currentColumn = this.playfieldInstance.columns[column];
-            Vector2 originPosition = currentColumn.getOriginPosition(starttime);
-            Vector2 receptorPosition = currentColumn.getReceptorPositionForNotes(starttime);
+            Vector2 originPosition = currentColumn.OriginPositionAt(starttime);
+            Vector2 receptorPosition = currentColumn.ReceptorPositionAt(starttime);
             int index = 0;
 
             float blend = 1.0f / (notePath.Count + 1);
@@ -280,8 +284,8 @@ namespace StorybrewScripts
 
             List<Anchor> notePath = this.notePathByColumn[column];
             Column currentColumn = this.playfieldInstance.columns[column];
-            Vector2 originPosition = currentColumn.getOriginPosition(starttime);
-            Vector2 receptorPosition = currentColumn.getReceptorPosition(starttime);
+            Vector2 originPosition = currentColumn.OriginPositionAt(starttime);
+            Vector2 receptorPosition = currentColumn.ReceptorPositionAt(starttime);
 
             int index = 0;
 
@@ -380,8 +384,8 @@ namespace StorybrewScripts
 
                     Column selectedColumn = this.playfieldInstance.columns[currentColumn];
 
-                    Vector2 originPosition = selectedColumn.getOriginPosition(starttime);
-                    Vector2 receptorPosition = selectedColumn.getReceptorPosition(starttime);
+                    Vector2 originPosition = selectedColumn.OriginPositionAt(starttime);
+                    Vector2 receptorPosition = selectedColumn.ReceptorPositionAt(starttime);
 
                     float blend = 1.0f / (notePath.Count - 1);
                     int index = 0;
@@ -407,8 +411,8 @@ namespace StorybrewScripts
                 List<Anchor> notePath = notePathByColumn[column];
 
                 Column selectedColumn = this.playfieldInstance.columns[column];
-                Vector2 originPosition = selectedColumn.getOriginPosition(starttime);
-                Vector2 receptorPosition = selectedColumn.getReceptorPosition(starttime);
+                Vector2 originPosition = selectedColumn.OriginPositionAt(starttime);
+                Vector2 receptorPosition = selectedColumn.ReceptorPositionAt(starttime);
 
                 float blend = 1.0f / (notePath.Count - 1);
                 int index = 0;
@@ -492,8 +496,8 @@ namespace StorybrewScripts
 
                         List<Anchor> notePath = this.notePathByColumn[type];
                         Column currentColumn = this.playfieldInstance.columns[type];
-                        Vector2 originPosition = currentColumn.getOriginPosition(currentTime + localIterationRate);
-                        Vector2 receptorPosition = currentColumn.getReceptorPositionForNotes(currentTime + localIterationRate);
+                        Vector2 originPosition = currentColumn.OriginPositionAt(currentTime + localIterationRate);
+                        Vector2 receptorPosition = currentColumn.ReceptorPositionAt(currentTime + localIterationRate);
 
                         int index = 0;
                         float blend = 1.0f / (notePath.Count - 1);
@@ -636,6 +640,11 @@ namespace StorybrewScripts
         public void changeUpdateRate(double time, double updatesPerSecond)
         {
             updatesPerSecondDictionary.Add(Math.Max(time - this.easetime, 0), updatesPerSecond);
+        }
+
+        public void SetColor(Color4 color)
+        {
+            this.color = color;
         }
     }
 }

--- a/Draw/Drawer.cs
+++ b/Draw/Drawer.cs
@@ -65,7 +65,7 @@ namespace storyboard.scriptslibrary.maniaModCharts.Draw
 
         public void setNoteRotationPrecision(float value)
         {
-            this.NoteScalePrecision = value;
+            this.NoteRotationPrecision = value;
         }
 
         public void setNoteFadePrecision(float value)

--- a/Draw/Renderers/ByAnchors.cs
+++ b/Draw/Renderers/ByAnchors.cs
@@ -30,6 +30,8 @@ namespace StorybrewScripts
             foreach (Column column in playfieldInstance.columns.Values)
             {
                 RenderReceptor.Render(instance, column, duration);
+                RenderOrigin.Render(instance, column);
+
                 List<Anchor> notePath = instance.notePathByColumn[column.type];
                 Dictionary<double, Note> notes = playfieldInstance.columnNotes[column.type];
                 var keysInRange = notes.Keys.Where(hittime => hittime >= starttime && hittime - easetime <= endtime).ToList();
@@ -48,7 +50,7 @@ namespace StorybrewScripts
                     double currentTime = note.starttime - easetime - localIterationRate;
                     double renderStartTime = Math.Max(currentTime, starttime);
                     double renderEndTime = Math.Min(note.endtime, endtime);
-                    Vector2 currentPosition = column.origin.getCurrentPosition(currentTime);
+                    Vector2 currentPosition = column.origin.PositionAt(currentTime);
                     float progress = 0f;
                     double iteratedTime = 0;
                     float initialFade = 1f;
@@ -71,6 +73,7 @@ namespace StorybrewScripts
                     }
 
                     double startRotation = note.getRotation(currentTime);
+                    note.Scale(currentTime, currentTime, OsbEasing.None, column.origin.ScaleAt(currentTime), column.origin.ScaleAt(currentTime));
 
                     switch (type)
                     {
@@ -108,11 +111,11 @@ namespace StorybrewScripts
                                     Vector2 endPos = notePath[n + 1].sprite.PositionAt(currentTime + localIterationRate);
 
                                     Vector2 newPosition = Vector2.Lerp(startPos, endPos, easedProgress);
-                                    Vector2 receptorPosition = column.receptor.getCurrentPosition(currentTime + localIterationRate);
-                                    Vector2 originScale = column.origin.getCurrentScale(currentTime + localIterationRate);
-                                    Vector2 receptorScale = column.receptor.getCurrentScale(currentTime + localIterationRate);
+                                    Vector2 receptorPosition = column.receptor.PositionAt(currentTime + localIterationRate);
+                                    Vector2 originScale = column.origin.ScaleAt(currentTime + localIterationRate);
+                                    Vector2 receptorScale = column.receptor.ScaleAt(currentTime + localIterationRate);
                                     Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
-                                    startRotation = column.receptor.getCurrentRotaion(currentTime + localIterationRate);
+                                    startRotation = column.receptor.RotationAt(currentTime + localIterationRate);
 
                                     double theta = 0;
                                     if (rotateToFaceReceptor)
@@ -153,9 +156,9 @@ namespace StorybrewScripts
                                     Vector2 endPos = notePath[n + 1].sprite.PositionAt(currentTime + localIterationRate);
 
                                     Vector2 newPosition = Vector2.Lerp(startPos, endPos, easedProgress);
-                                    Vector2 receptorPosition = column.receptor.getCurrentPosition(currentTime + localIterationRate);
-                                    Vector2 originScale = column.origin.getCurrentScale(currentTime + localIterationRate);
-                                    Vector2 receptorScale = column.receptor.getCurrentScale(currentTime + localIterationRate);
+                                    Vector2 receptorPosition = column.receptor.PositionAt(currentTime + localIterationRate);
+                                    Vector2 originScale = column.origin.ScaleAt(currentTime + localIterationRate);
+                                    Vector2 receptorScale = column.receptor.ScaleAt(currentTime + localIterationRate);
                                     Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
 
                                     double theta = 0;
@@ -185,9 +188,9 @@ namespace StorybrewScripts
                                 // Apply easing to the progress
                                 float easedProgress = (float)easing.Ease(progress);
 
-                                Vector2 receptorPosition = column.getReceptorPositionForNotes(currentTime);
-                                Vector2 originScale = column.origin.getCurrentScale(currentTime);
-                                Vector2 receptorScale = column.receptor.getCurrentScale(currentTime);
+                                Vector2 receptorPosition = column.ReceptorPositionAt(currentTime);
+                                Vector2 originScale = column.origin.ScaleAt(currentTime);
+                                Vector2 receptorScale = column.receptor.ScaleAt(currentTime);
                                 Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
                                 List<Vector2> points = instance.GetPathAnchorVectors(notePath, currentTime);
                                 Vector2 newPosition = BezierCurve.CalculatePoint(points, easedProgress);
@@ -223,7 +226,7 @@ namespace StorybrewScripts
                         double sliderStartime = part.Timestamp;
                         OsbSprite sprite = part.Sprite;
                         double sliderCurrentTime = sliderStartime - easetime - localIterationRate;
-                        Vector2 currentSliderPositon = column.origin.getCurrentPosition(sliderCurrentTime);
+                        Vector2 currentSliderPositon = column.origin.PositionAt(sliderCurrentTime);
                         double sliderRenderStartTime = Math.Max(sliderCurrentTime, sliderStartime);
                         double sliderRenderEndTime = Math.Min(sliderStartime + 0.1f, endtime);
 
@@ -236,7 +239,7 @@ namespace StorybrewScripts
                         float defaultScaleX = 0.7f / 0.5f;
                         float defaultScaleY = 0.14f / 0.5f * ((float)part.Duration / 20f); // This scaled was based on 20ms long sliderParts
 
-                        Vector2 newScale = new Vector2(defaultScaleX * column.origin.getCurrentScale(sliderCurrentTime).X, defaultScaleY * column.origin.getCurrentScale(sliderCurrentTime).Y);
+                        Vector2 newScale = new Vector2(defaultScaleX * column.origin.ScaleAt(sliderCurrentTime).X, defaultScaleY * column.origin.ScaleAt(sliderCurrentTime).Y);
                         SliderScale.Add(sliderCurrentTime, newScale, EasingFunctions.ToEasingFunction(easing));
 
                         float sliderProgress = 0;
@@ -272,9 +275,9 @@ namespace StorybrewScripts
                                         Vector2 endPos = notePath[n + 1].sprite.PositionAt(sliderCurrentTime + localIterationRate);
 
                                         Vector2 newPosition = Vector2.Lerp(startPos, endPos, easedProgress);
-                                        Vector2 receptorPosition = column.receptor.getCurrentPosition(sliderCurrentTime + localIterationRate);
-                                        Vector2 originScale = column.origin.getCurrentScale(sliderCurrentTime + localIterationRate);
-                                        Vector2 receptorScale = column.receptor.getCurrentScale(sliderCurrentTime + localIterationRate);
+                                        Vector2 receptorPosition = column.receptor.PositionAt(sliderCurrentTime + localIterationRate);
+                                        Vector2 originScale = column.origin.ScaleAt(sliderCurrentTime + localIterationRate);
+                                        Vector2 receptorScale = column.receptor.ScaleAt(sliderCurrentTime + localIterationRate);
                                         Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
 
                                         double theta = 0;
@@ -287,7 +290,7 @@ namespace StorybrewScripts
                                         // If the note is already done
                                         if (sliderCurrentTime > note.starttime)
                                         {
-                                            Vector2 newNotePosition = column.receptor.getCurrentPosition(sliderCurrentTime + localIterationRate);
+                                            Vector2 newNotePosition = column.receptor.PositionAt(sliderCurrentTime + localIterationRate);
 
                                             double noteTheta = 0;
                                             Vector2 noteDelta = newNotePosition - currentPosition;
@@ -330,9 +333,9 @@ namespace StorybrewScripts
                                         Vector2 endPos = notePath[n + 1].sprite.PositionAt(sliderCurrentTime + localIterationRate);
 
                                         Vector2 newPosition = Vector2.Lerp(startPos, endPos, easedProgress);
-                                        Vector2 receptorPosition = column.receptor.getCurrentPosition(sliderCurrentTime + localIterationRate);
-                                        Vector2 originScale = column.origin.getCurrentScale(sliderCurrentTime + localIterationRate);
-                                        Vector2 receptorScale = column.receptor.getCurrentScale(sliderCurrentTime + localIterationRate);
+                                        Vector2 receptorPosition = column.receptor.PositionAt(sliderCurrentTime + localIterationRate);
+                                        Vector2 originScale = column.origin.ScaleAt(sliderCurrentTime + localIterationRate);
+                                        Vector2 receptorScale = column.receptor.ScaleAt(sliderCurrentTime + localIterationRate);
                                         Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
 
                                         double theta = 0;
@@ -345,7 +348,7 @@ namespace StorybrewScripts
                                         // If the note is already done
                                         if (sliderCurrentTime > note.starttime)
                                         {
-                                            Vector2 newNotePosition = column.receptor.getCurrentPosition(sliderCurrentTime + localIterationRate);
+                                            Vector2 newNotePosition = column.receptor.PositionAt(sliderCurrentTime + localIterationRate);
 
                                             double noteTheta = 0;
                                             Vector2 noteDelta = newNotePosition - currentPosition;
@@ -379,9 +382,9 @@ namespace StorybrewScripts
                                     // Apply easing to the progress
                                     float easedProgress = (float)easing.Ease(sliderProgress);
 
-                                    Vector2 receptorPosition = column.getReceptorPositionForNotes(sliderCurrentTime + localIterationRate);
-                                    Vector2 originScale = column.origin.getCurrentScale(sliderCurrentTime + localIterationRate);
-                                    Vector2 receptorScale = column.receptor.getCurrentScale(sliderCurrentTime + localIterationRate);
+                                    Vector2 receptorPosition = column.ReceptorPositionAt(sliderCurrentTime + localIterationRate);
+                                    Vector2 originScale = column.origin.ScaleAt(sliderCurrentTime + localIterationRate);
+                                    Vector2 receptorScale = column.receptor.ScaleAt(sliderCurrentTime + localIterationRate);
                                     Vector2 scaleProgress = Vector2.Lerp(originScale, receptorScale, easedProgress);
                                     List<Vector2> points = instance.GetPathAnchorVectors(notePath, sliderCurrentTime);
 
@@ -399,7 +402,7 @@ namespace StorybrewScripts
                                     // If the note is already done
                                     if (sliderCurrentTime > note.starttime)
                                     {
-                                        Vector2 newNotePosition = column.receptor.getCurrentPosition(sliderCurrentTime + localIterationRate);
+                                        Vector2 newNotePosition = column.receptor.PositionAt(sliderCurrentTime + localIterationRate);
 
                                         double noteTheta = 0;
                                         Vector2 noteDelta = newNotePosition - currentPosition;
@@ -442,7 +445,7 @@ namespace StorybrewScripts
                     scale.Simplify2dKeyframes(instance.NoteScalePrecision, v => v);
                     rotation.Simplify1dKeyframes(instance.NoteRotationPrecision, v => (float)v);
                     movement.ForEachPair((start, end) => note.Move(start.Time, end.Time - start.Time, OsbEasing.None, start.Value, end.Value));
-                    scale.ForEachPair((start, end) => note.Scale(start.Time, end.Time - start.Time, OsbEasing.None, start.Value, end.Value));
+                    scale.ForEachPair((start, end) => note.Scale(start.Time, end.Time, OsbEasing.None, start.Value, end.Value));
                     rotation.ForEachPair((start, end) => note.AbsoluteRotate(start.Time, end.Time - start.Time, OsbEasing.None, end.Value));
 
                     if (progress == 1)

--- a/Draw/Renderers/OriginToReceptor.cs
+++ b/Draw/Renderers/OriginToReceptor.cs
@@ -31,13 +31,13 @@ namespace StorybrewScripts
                 if (renderReceptor)
                     RenderReceptor.Render(instance, column, duration);
 
+                RenderOrigin.Render(instance, column);
+
                 Dictionary<double, Note> notes = playfieldInstance.columnNotes[column.type];
                 var keysInRange = notes.Keys.Where(hittime => hittime >= starttime && hittime - easetime <= endtime).ToList();
 
                 foreach (var key in keysInRange)
                 {
-
-
 
                     KeyframedValue<Vector2> movement = new KeyframedValue<Vector2>(null);
                     KeyframedValue<Vector2> scale = new KeyframedValue<Vector2>(null);
@@ -62,7 +62,7 @@ namespace StorybrewScripts
                     double currentTime = note.starttime - easetime - localIterationRate;
                     double renderStartTime = Math.Max(currentTime, starttime);
                     double renderEndTime = Math.Min(note.endtime, endtime);
-                    Vector2 currentPosition = column.origin.getCurrentPosition(currentTime);
+                    Vector2 currentPosition = column.origin.PositionAt(currentTime);
                     float progress = 0f;
                     double iteratedTime = 0;
                     float initialFade = 1;
@@ -86,6 +86,7 @@ namespace StorybrewScripts
                     }
 
                     double startRotation = note.getRotation(currentTime);
+                    note.Scale(currentTime, currentTime, OsbEasing.None, column.origin.ScaleAt(currentTime), column.origin.ScaleAt(currentTime));
 
                     do
                     {
@@ -115,13 +116,13 @@ namespace StorybrewScripts
                         // Apply easing to the progress
                         float easedProgress = (float)easing.Ease(progress);
 
-                        Vector2 originPosition = column.origin.getCurrentPosition(currentTime + localIterationRate);
-                        Vector2 receptorPosition = column.receptor.getCurrentPosition(currentTime + localIterationRate);
+                        Vector2 originPosition = column.origin.PositionAt(currentTime + localIterationRate);
+                        Vector2 receptorPosition = column.receptor.PositionAt(currentTime + localIterationRate);
                         Vector2 newPosition = Vector2.Lerp(originPosition, receptorPosition, easedProgress);
-                        Vector2 originScale = column.origin.getCurrentScale(currentTime + localIterationRate);
-                        Vector2 receptorScale = column.receptor.getCurrentScale(currentTime + localIterationRate);
+                        Vector2 originScale = column.origin.ScaleAt(currentTime + localIterationRate);
+                        Vector2 receptorScale = column.receptor.ScaleAt(currentTime + localIterationRate);
                         Vector2 scaleProgress = Vector2.Lerp(receptorScale, originScale, easedProgress);
-                        startRotation = column.receptor.getCurrentRotaion(currentTime + localIterationRate);
+                        startRotation = column.receptor.RotationAt(currentTime + localIterationRate);
 
                         double theta = 0;
                         if (progress < 0.15 && rotateToFaceReceptor)
@@ -156,7 +157,7 @@ namespace StorybrewScripts
                         double sliderStartime = part.Timestamp;
                         OsbSprite sprite = part.Sprite;
                         double sliderCurrentTime = sliderStartime - easetime - sliderIterationLenght;
-                        Vector2 currentSliderPositon = column.origin.getCurrentPosition(sliderCurrentTime);
+                        Vector2 currentSliderPositon = column.origin.PositionAt(sliderCurrentTime);
                         double sliderRenderStartTime = Math.Max(sliderStartime - easetime, starttime);
                         double sliderRenderEndTime = Math.Min(sliderStartime, endtime);
                         float sliderProgress = 0;
@@ -180,7 +181,7 @@ namespace StorybrewScripts
                         float defaultScaleX = 0.7f / 0.5f;
                         float defaultScaleY = 0.14f / 0.5f * ((float)part.Duration / 20f); // This scaled was based on 20ms long sliderParts
 
-                        Vector2 newScale = new Vector2(defaultScaleX * column.origin.getCurrentScale(sliderCurrentTime).X, defaultScaleY * column.origin.getCurrentScale(sliderCurrentTime).Y);
+                        Vector2 newScale = new Vector2(defaultScaleX * column.origin.ScaleAt(sliderCurrentTime).X, defaultScaleY * column.origin.ScaleAt(sliderCurrentTime).Y);
 
                         SliderMovement.Add(sliderCurrentTime, currentSliderPositon, EasingFunctions.ToEasingFunction(easing));
                         SliderScale.Add(sliderCurrentTime, newScale, EasingFunctions.ToEasingFunction(easing));
@@ -207,10 +208,10 @@ namespace StorybrewScripts
                             // Apply easing to the progress
                             float easedProgress = (float)easing.Ease(sliderProgress);
 
-                            Vector2 originPosition = column.origin.getCurrentPosition(sliderCurrentTime + sliderIterationLenght);
-                            Vector2 receptorPosition = column.receptor.getCurrentPosition(sliderCurrentTime + sliderIterationLenght);
+                            Vector2 originPosition = column.origin.PositionAt(sliderCurrentTime + sliderIterationLenght);
+                            Vector2 receptorPosition = column.receptor.PositionAt(sliderCurrentTime + sliderIterationLenght);
                             Vector2 newPosition = Vector2.Lerp(originPosition, receptorPosition, easedProgress);
-                            Vector2 receptorScale = column.receptor.getCurrentScale(sliderCurrentTime + sliderIterationLenght);
+                            Vector2 receptorScale = column.receptor.ScaleAt(sliderCurrentTime + sliderIterationLenght);
                             Vector2 renderedReceptorPosition = column.receptor.renderedSprite.PositionAt(sliderCurrentTime);
 
                             double theta = 0;
@@ -226,14 +227,14 @@ namespace StorybrewScripts
                             // If the note is already done
                             if (sliderCurrentTime > note.starttime)
                             {
-                                Vector2 newNotePosition = column.receptor.getCurrentPosition(sliderCurrentTime + sliderIterationLenght);
+                                Vector2 newNotePosition = column.receptor.PositionAt(sliderCurrentTime + sliderIterationLenght);
                                 movement.Add(sliderCurrentTime + sliderIterationLenght, newNotePosition, EasingFunctions.ToEasingFunction(easing));
                                 scale.Add(sliderCurrentTime + sliderIterationLenght, receptorScale, EasingFunctions.ToEasingFunction(easing));
 
                                 currentPosition = newNotePosition;
                             }
 
-                            newScale = new Vector2(defaultScaleX * column.origin.getCurrentScale(sliderCurrentTime).X, defaultScaleY * column.origin.getCurrentScale(sliderCurrentTime).Y);
+                            newScale = new Vector2(defaultScaleX * column.origin.ScaleAt(sliderCurrentTime).X, defaultScaleY * column.origin.ScaleAt(sliderCurrentTime).Y);
 
                             SliderMovement.Add(sliderCurrentTime + sliderIterationLenght, newPosition, EasingFunctions.ToEasingFunction(easing));
                             SliderScale.Add(sliderCurrentTime + sliderIterationLenght, newScale, EasingFunctions.ToEasingFunction(easing));
@@ -261,7 +262,7 @@ namespace StorybrewScripts
                     scale.Simplify2dKeyframes(instance.NoteScalePrecision, v => v);
                     rotation.Simplify1dKeyframes(instance.NoteRotationPrecision, v => (float)v);
                     movement.ForEachPair((start, end) => note.Move(start.Time, end.Time - start.Time, OsbEasing.None, start.Value, end.Value));
-                    scale.ForEachPair((start, end) => note.Scale(start.Time, end.Time - start.Time, OsbEasing.None, start.Value, end.Value));
+                    scale.ForEachPair((start, end) => note.Scale(start.Time, end.Time, OsbEasing.None, start.Value, end.Value));
                     rotation.ForEachPair((start, end) => note.Rotate(start.Time, end.Time - start.Time, OsbEasing.None, start.Value, end.Value));
 
                     if (progress == 1 && renderReceptor)

--- a/Draw/Renderers/RenderOrigin.cs
+++ b/Draw/Renderers/RenderOrigin.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenTK;
+using storyboard.scriptslibrary.maniaModCharts.effects;
+using StorybrewCommon.Animations;
+using StorybrewCommon.Storyboarding;
+
+namespace StorybrewScripts
+{
+    public static class RenderOrigin
+    {
+
+        public static void Render(DrawInstance instance, Column column) 
+        {
+
+            Playfield playfieldInstance = instance.playfieldInstance;
+
+            KeyframedValue<Vector2> movement = new KeyframedValue<Vector2>(null);
+
+            NoteOrigin origin = column.origin;
+
+            double relativeTime = playfieldInstance.starttime + 1;
+
+            var pos = origin.PositionAt(relativeTime);
+
+            float lastX = pos.X;
+            float lastY = pos.Y;
+
+            while (relativeTime <= playfieldInstance.endtime)
+            {
+                float x = lastX;
+                float y = lastY;
+
+                if (origin.positionX.ContainsKey(relativeTime))
+                {
+                    x = origin.positionX[relativeTime];
+                    lastX = x;
+                }
+
+                if (origin.positionY.ContainsKey(relativeTime))
+                {
+                    y = origin.positionY[relativeTime];
+                    lastX = y;
+                }
+
+                movement.Add(relativeTime, new Vector2(x, y));
+
+                relativeTime += playfieldInstance.delta;
+            }
+
+            movement.Simplify2dKeyframes(1, v => v);
+            movement.ForEachPair((start, end) => origin.originSprite.Move(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
+
+        }
+
+    }
+}

--- a/Draw/Renderers/RenderOrigin.cs
+++ b/Draw/Renderers/RenderOrigin.cs
@@ -12,7 +12,7 @@ namespace StorybrewScripts
     public static class RenderOrigin
     {
 
-        public static void Render(DrawInstance instance, Column column) 
+        public static void Render(DrawInstance instance, Column column)
         {
 
             Playfield playfieldInstance = instance.playfieldInstance;
@@ -21,32 +21,13 @@ namespace StorybrewScripts
 
             NoteOrigin origin = column.origin;
 
-            double relativeTime = playfieldInstance.starttime + 1;
+            double relativeTime = playfieldInstance.starttime;
 
             var pos = origin.PositionAt(relativeTime);
-
-            float lastX = pos.X;
-            float lastY = pos.Y;
-
+            
             while (relativeTime <= playfieldInstance.endtime)
             {
-                float x = lastX;
-                float y = lastY;
-
-                if (origin.positionX.ContainsKey(relativeTime))
-                {
-                    x = origin.positionX[relativeTime];
-                    lastX = x;
-                }
-
-                if (origin.positionY.ContainsKey(relativeTime))
-                {
-                    y = origin.positionY[relativeTime];
-                    lastX = y;
-                }
-
-                movement.Add(relativeTime, new Vector2(x, y));
-
+                movement.Add(relativeTime, origin.PositionAt(relativeTime));
                 relativeTime += playfieldInstance.delta;
             }
 

--- a/Draw/Renderers/RenderReceptor.cs
+++ b/Draw/Renderers/RenderReceptor.cs
@@ -36,35 +36,25 @@ namespace StorybrewScripts
             double iterationLenght = 1000 / instance.updatesPerSecond;
 
             Receptor receptor = column.receptor;
-            Vector2 currentPosition = receptor.PositionAt(currentTime);
 
             receptor.renderedSprite.Fade(starttime - 2500, 0);
             receptor.renderedSprite.Fade(starttime, 1);
             receptor.renderedSprite.Fade(endTime, 0);
 
-            double relativeTime = currentTime;
+            double relativeTime = playfieldInstance.starttime;
 
-            Vector2 currentPos = receptor.PositionAt(currentTime);
+            var pos = receptor.PositionAt(relativeTime);
 
             while (relativeTime <= playfieldInstance.endtime)
             {
 
-                if (receptor.positionX.ContainsKey(relativeTime))
-                {
-                    float x = receptor.positionX[relativeTime];
-                    currentPos.X = x;
-                }
-
-                if (receptor.positionY.ContainsKey(relativeTime))
-                {
-                    float y = receptor.positionY[relativeTime];
-                    currentPos.Y = y;
-                }
-
-                movement.Add(relativeTime, currentPos);
+                movement.Add(relativeTime, receptor.PositionAt(relativeTime));
 
                 relativeTime += playfieldInstance.delta;
             }
+
+            movement.Simplify2dKeyframes(1, v => v);
+            movement.ForEachPair((start, end) => receptor.renderedSprite.Move(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
 
 
             var foundEntry = instance.findEffectByReferenceTime(currentTime);
@@ -78,7 +68,7 @@ namespace StorybrewScripts
                 receptor.Render(currentTime, endTime);
             }
 
-            while (currentTime < endTime)
+            /*while (currentTime < endTime)
             {
 
                 foundEntry = instance.findEffectByReferenceTime(currentTime);
@@ -98,10 +88,7 @@ namespace StorybrewScripts
                 }
 
                 currentTime += iterationLenght;
-            }
-
-            movement.Simplify2dKeyframes(1, v => v);
-            movement.ForEachPair((start, end) => receptor.renderedSprite.Move(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
+            }*/
 
 
         }

--- a/Draw/Renderers/RenderReceptor.cs
+++ b/Draw/Renderers/RenderReceptor.cs
@@ -36,13 +36,36 @@ namespace StorybrewScripts
             double iterationLenght = 1000 / instance.updatesPerSecond;
 
             Receptor receptor = column.receptor;
-            Vector2 currentPosition = receptor.getCurrentPosition(currentTime);
+            Vector2 currentPosition = receptor.PositionAt(currentTime);
 
             receptor.renderedSprite.Fade(starttime - 2500, 0);
             receptor.renderedSprite.Fade(starttime, 1);
             receptor.renderedSprite.Fade(endTime, 0);
 
-            movement.Add(currentTime, currentPosition);
+            double relativeTime = currentTime;
+
+            Vector2 currentPos = receptor.PositionAt(currentTime);
+
+            while (relativeTime <= playfieldInstance.endtime)
+            {
+
+                if (receptor.positionX.ContainsKey(relativeTime))
+                {
+                    float x = receptor.positionX[relativeTime];
+                    currentPos.X = x;
+                }
+
+                if (receptor.positionY.ContainsKey(relativeTime))
+                {
+                    float y = receptor.positionY[relativeTime];
+                    currentPos.Y = y;
+                }
+
+                movement.Add(relativeTime, currentPos);
+
+                relativeTime += playfieldInstance.delta;
+            }
+
 
             var foundEntry = instance.findEffectByReferenceTime(currentTime);
 
@@ -60,7 +83,7 @@ namespace StorybrewScripts
 
                 foundEntry = instance.findEffectByReferenceTime(currentTime);
 
-                if (foundEntry.Value != null)
+                if (foundEntry.Value != null && foundEntry.Value.effektType == EffectType.TransformPlayfield3D)
                 {
                     receptor.RenderTransformed(currentTime, endTime, foundEntry.Value.reference);
                 }
@@ -74,20 +97,12 @@ namespace StorybrewScripts
                         renderedReceptor.Fade(currentTime, receptorFade.value);
                 }
 
-                Vector2 newPosition = receptor.getCurrentPosition(currentTime);
-
-                movement.Add(currentTime, newPosition);
-                scale.Add(currentTime, receptor.receptorSprite.ScaleAt(currentTime));
-                rotation.Add(currentTime, receptor.receptorSprite.RotationAt(currentTime));
                 currentTime += iterationLenght;
             }
 
-            //movement.Simplify2dKeyframes(ReceptorMovementPrecision, v => v);
-            //scale.Simplify2dKeyframes(ReceptorScalePrecision, v => v);
-            //rotation.Simplify1dKeyframes(ReceptorRotationPrecision, v => (float)v);
-            scale.ForEachPair((start, end) => receptor.renderedSprite.ScaleVec(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
+            movement.Simplify2dKeyframes(1, v => v);
             movement.ForEachPair((start, end) => receptor.renderedSprite.Move(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
-            rotation.ForEachPair((start, end) => receptor.renderedSprite.Rotate(OsbEasing.None, start.Time, end.Time, start.Value, end.Value));
+
 
         }
 

--- a/PlayField/Column/Column.cs
+++ b/PlayField/Column/Column.cs
@@ -11,8 +11,13 @@ namespace StorybrewScripts
 {
     public enum ColumnType
     {
-        one, two, three, four, all
+        all = 0,
+        one = 1,
+        two = 2,
+        three = 3,
+        four = 4
     };
+
 
     public class Column
     {
@@ -31,7 +36,7 @@ namespace StorybrewScripts
         public double bpm;
 
 
-        public Column(double offset, ColumnType type, String receptorSpritePath, StoryboardLayer columnLayer, CommandScale scale, double starttime)
+        public Column(double offset, ColumnType type, String receptorSpritePath, StoryboardLayer columnLayer, CommandScale scale, double starttime, double delta)
         {
             this.offset = offset;
             this.type = type;
@@ -55,15 +60,14 @@ namespace StorybrewScripts
                     break;
             }
 
-            this.receptor = new Receptor(receptorSpritePath, rotation, columnLayer, scale, starttime, this.type);
-            this.origin = new NoteOrigin(receptorSpritePath, rotation, columnLayer, scale, starttime);
+            receptor = new Receptor(receptorSpritePath, rotation, columnLayer, scale, starttime, this.type, delta);
+            origin = new NoteOrigin(receptorSpritePath, rotation, columnLayer, scale, starttime, delta);
 
         }
 
         // This methods sets the bpm for the receptor glint on full beats
         public void setBPM(double bpm, double bpmOffset)
         {
-
             this.bpm = bpm;
             this.bpmOffset = bpmOffset;
 
@@ -72,106 +76,98 @@ namespace StorybrewScripts
 
             origin.bpm = bpm;
             origin.bpmOffset = bpmOffset;
-
         }
 
-        public double MoveColumn(double starttime, double duration, Vector2 newColumnPosition, Vector2 newOriginPosition, OsbEasing easing)
+        public void MoveColumn(OsbEasing easing, double starttime, double endtime, Vector2 from, Vector2 to)
         {
-            this.receptor.MoveReceptor(starttime, newColumnPosition, easing, duration);
-            this.origin.MoveOrigin(starttime, newOriginPosition, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorAbsolute(easing, starttime, endtime, from, to);
+            origin.MoveOriginAbsolute(easing, starttime, endtime, from, to);
         }
 
-        public double MoveColumnRelative(double starttime, double duration, Vector2 offset, OsbEasing easing)
+        public void MoveColumnRelative(OsbEasing easing, double starttime, double endtime, Vector2 offset)
         {
-            this.receptor.MoveReceptorRelative(starttime, offset, easing, duration);
-            this.origin.MoveOriginRelative(starttime, offset, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorRelative(easing, starttime, endtime, offset);
+            origin.MoveOriginRelative(easing, starttime, endtime, offset);
         }
 
-        public double MoveColumnRelativeX(double starttime, double duration, double value, OsbEasing easing)
+        public void MoveColumnRelativeX(OsbEasing easing, double starttime, double endtime, float value)
         {
-            this.receptor.MoveReceptorRelativeX(starttime, value, easing, duration);
-            this.origin.MoveOriginRelativeX(starttime, value, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorRelativeX(easing, starttime, endtime, value);
+            origin.MoveOriginRelativeX(easing, starttime, endtime, value);
         }
 
-        public double MoveColumnRelativeY(double starttime, double duration, double value, OsbEasing easing)
+        public void MoveColumnRelativeY(OsbEasing easing, double starttime, double endtime, float value)
         {
-            this.receptor.MoveReceptorRelativeY(starttime, value, easing, duration);
-            this.origin.MoveOriginRelativeY(starttime, value, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorRelativeY(easing, starttime, endtime, value);
+            origin.MoveOriginRelativeY(easing, starttime, endtime, value);
         }
 
-        public double MoveReceptor(double starttime, double duration, Vector2 newReceptorPosition, OsbEasing easing)
+        public void MoveReceptorAbsolute(double starttime, Vector2 newReceptorPosition)
         {
-
-            this.receptor.MoveReceptor(starttime, newReceptorPosition, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorAbsolute(starttime, newReceptorPosition);
         }
 
-        public double MoveReceptorRelative(double starttime, double duration, Vector2 offset, OsbEasing easing)
+        public void MoveReceptorAbsolute(OsbEasing ease, double starttime, double endtime, Vector2 startPos, Vector2 endPos)
         {
-
-            this.receptor.MoveReceptorRelative(starttime, offset, easing, duration);
-
-            return starttime + duration;
+            receptor.MoveReceptorAbsolute(ease, starttime, endtime, startPos, endPos);
         }
 
-
-        public double RotateReceptorRelative(double starttime, double duration, OsbEasing easing, double rotation)
+        public void MoveReceptor(OsbEasing ease, double starttime, double endtime, Vector2 from, Vector2 to)
         {
-
-            this.receptor.RotateReceptor(starttime, duration, easing, rotation);
-
-            return starttime + duration;
+            receptor.MoveReceptorAbsolute(ease, starttime, endtime, from, to);
         }
 
-        public double RotateReceptor(double starttime, double duration, OsbEasing easing, double rotation)
+        public void MoveReceptorRelative(OsbEasing easing, double starttime, double endtime, Vector2 offset)
+        {
+            receptor.MoveReceptorRelative(easing, starttime, endtime, offset);
+        }
+
+        public void RotateReceptorRelative(OsbEasing easing, double starttime, double endtime, double rotation)
+        {
+            receptor.RotateReceptor(easing, starttime, endtime, rotation);
+        }
+
+        public void RotateReceptor(OsbEasing easing, double starttime, double endtime, double rotation)
+        {
+            receptor.RotateReceptorAbsolute(easing, starttime, endtime, rotation);
+        }
+
+        public void MoveOrigin(double starttime, Vector2 newOriginPosition)
         {
 
-            this.receptor.RotateReceptorAbsolute(starttime, duration, easing, rotation);
-
-            return starttime + duration;
+            origin.MoveOriginAbsolute(starttime, newOriginPosition);
         }
 
-        public double MoveOrigin(double starttime, double duration, Vector2 newOriginPosition, OsbEasing easing)
+        public Vector2 OriginPositionAt(double starttime)
         {
-
-            this.origin.MoveOrigin(starttime, newOriginPosition, easing, duration);
-
-            return starttime + duration;
+            return origin.PositionAt(starttime);
         }
 
-        public Vector2 getOriginPosition(double starttime)
+        public float OriginRotationAt(double starttime)
         {
-            return this.origin.getCurrentPosition(starttime);
+            return origin.RotationAt(starttime);
         }
 
-        public Vector2 getReceptorPosition(double starttime)
+        public Vector2 OriginScaleAt(double starttime)
         {
-            return this.receptor.getCurrentPosition(starttime);
+            return origin.ScaleAt(starttime);
         }
 
-        public Vector2 getReceptorPositionForNotes(double starttime)
+        public Vector2 ReceptorPositionAt(double starttime)
         {
-            return this.receptor.getCurrentPositionForNotes(starttime);
+            return receptor.PositionAt(starttime);
         }
 
-        public double getReceptorRotation(double starttime)
+        public double ReceptorRotationAt(double starttime)
         {
-            return this.receptor.getCurrentRotaion(starttime);
+            return receptor.RotationAt(starttime);
         }
 
-        public List<Operation> executeKeyFrames()
+        public Vector2 ReceptorScaleAt(double starttime)
         {
-            return receptor.executeOperations();
+            return receptor.ScaleAt(starttime);
         }
+
 
     }
 }

--- a/PlayField/Column/Column.cs
+++ b/PlayField/Column/Column.cs
@@ -112,11 +112,6 @@ namespace StorybrewScripts
             receptor.MoveReceptorAbsolute(ease, starttime, endtime, startPos, endPos);
         }
 
-        public void MoveReceptor(OsbEasing ease, double starttime, double endtime, Vector2 from, Vector2 to)
-        {
-            receptor.MoveReceptorAbsolute(ease, starttime, endtime, from, to);
-        }
-
         public void MoveReceptorRelative(OsbEasing easing, double starttime, double endtime, Vector2 offset)
         {
             receptor.MoveReceptorRelative(easing, starttime, endtime, offset);
@@ -132,10 +127,22 @@ namespace StorybrewScripts
             receptor.RotateReceptorAbsolute(easing, starttime, endtime, rotation);
         }
 
-        public void MoveOrigin(double starttime, Vector2 newOriginPosition)
+        public void MoveOriginAbsoluite(double starttime, Vector2 newOriginPosition)
         {
 
             origin.MoveOriginAbsolute(starttime, newOriginPosition);
+        }
+
+        public void MoveOriginAbsoluite(OsbEasing ease, double starttime, double endtime, Vector2 startPos, Vector2 endPos)
+        {
+
+            origin.MoveOriginAbsolute(ease, starttime, endtime, startPos, endPos);
+        }
+
+        public void MoveOriginRelative(OsbEasing ease, double starttime, double endtime, Vector2 offset)
+        {
+
+            origin.MoveOriginRelative(ease, starttime, endtime, offset);
         }
 
         public Vector2 OriginPositionAt(double starttime)

--- a/PlayField/Column/NoteOrigin.cs
+++ b/PlayField/Column/NoteOrigin.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenTK;
+using StorybrewCommon.Animations;
+using StorybrewCommon.Scripting;
 using StorybrewCommon.Storyboarding;
 using StorybrewCommon.Storyboarding.CommandValues;
 
@@ -13,9 +15,11 @@ namespace StorybrewScripts
     {
 
         public string receptorSpritePath = "";
-        public Vector2 position = new Vector2(0, 0);
         public StoryboardLayer layer;
         public OsbSprite originSprite;
+
+        public Dictionary<double, float> positionX = new Dictionary<double, float>();
+        public Dictionary<double, float> positionY = new Dictionary<double, float>();
 
         public double bpmOffset;
         public double bpm;
@@ -25,18 +29,24 @@ namespace StorybrewScripts
         // Rotation in radiants
         public double rotation = 0f;
 
-        public NoteOrigin(String receptorSpritePath, double rotation, StoryboardLayer layer, CommandScale scale, double starttime)
+        public double deltaIncrement = 1;
+
+        public NoteOrigin(String receptorSpritePath, double rotation, StoryboardLayer layer, CommandScale scale, double starttime, double delta)
         {
 
-            OsbSprite receptor = layer.CreateSprite("sb/transparent.png", OsbOrigin.Centre);
-            receptor.Rotate(starttime, rotation);
-            receptor.ScaleVec(starttime, scale);
+            this.deltaIncrement = delta;
 
+            OsbSprite origin = layer.CreateSprite("sb/transparent.png", OsbOrigin.Centre);
+            origin.Rotate(starttime - 1, rotation);
+            origin.ScaleVec(starttime - 1, scale);
+
+            positionX.Add(0, 0);
+            positionY.Add(0, 0);
 
             this.receptorSpritePath = receptorSpritePath;
             this.rotation = rotation;
             this.layer = layer;
-            this.originSprite = receptor;
+            this.originSprite = origin;
 
         }
 
@@ -49,164 +59,145 @@ namespace StorybrewScripts
 
         }
 
-        public void MoveOrigin(double starttime, Vector2 newPosition, OsbEasing ease, double duration)
+        public void MoveOriginAbsolute(double starttime, Vector2 endPos)
         {
-            OsbSprite receptor = this.originSprite;
 
-            if (duration == 0)
-            {
-                receptor.Move(starttime, newPosition);
-            }
-            else
-            {
-                receptor.Move(ease, starttime, starttime + duration, getCurrentPosition(starttime - 1), newPosition);
-            }
+            AddXValue(starttime, endPos.X, endPos.X, true);
+            AddYValue(starttime, endPos.Y, endPos.Y, true);
 
-            this.position = newPosition;
 
         }
 
-        public void MoveOriginRelative(double starttime, Vector2 offset, OsbEasing ease, double duration)
+        public void MoveOriginAbsolute(OsbEasing ease, double starttime, double endtime, Vector2 startPos, Vector2 endPos)
         {
-            OsbSprite receptor = this.originSprite;
 
-            Vector2 originalPosition = getCurrentPosition(starttime);
-            Vector2 newPosition = Vector2.Add(originalPosition, offset);
-
-            if (duration == 0)
+            if (starttime == endtime)
             {
-                receptor.Move(starttime, newPosition);
-            }
-            else
-            {
-                receptor.Move(ease, starttime, starttime + duration, originalPosition, newPosition);
+                AddXValue(starttime, endPos.X, endPos.X, true);
+                AddYValue(starttime, endPos.Y, endPos.Y, true);
+                return;
             }
 
-            this.position = newPosition;
+            easeProgressAbsolute(ease, starttime, endtime, startPos, endPos);
 
         }
 
-        public void MoveOriginRelativeX(double starttime, double value, OsbEasing ease, double duration)
+        public void MoveOriginRelative(OsbEasing ease, double starttime, double endtime, Vector2 offset)
+        {
+
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, offset.X, offset.X);
+                AddYValue(starttime, offset.Y, offset.Y);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, offset);
+
+        }
+
+        public void MoveOriginRelative(OsbEasing ease, double starttime, double endtime, Vector2 offset, Vector2 absolute)
+        {
+
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, offset.X, absolute.X);
+                AddYValue(starttime, offset.Y, absolute.Y);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, offset);
+
+        }
+
+        public void MoveOriginRelativeX(OsbEasing ease, double starttime, double endtime, float value)
+        {
+
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, value, value);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, new Vector2(value, 0));
+
+        }
+
+        public void MoveOriginRelativeY(OsbEasing ease, double starttime, double endtime, float value)
+        {
+            if (starttime == endtime)
+            {
+                AddYValue(starttime, value, value);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, new Vector2(0, value));
+
+        }
+
+        public void ScaleReceptor(OsbEasing ease, double starttime, double endtime, Vector2 newScale)
         {
             OsbSprite receptor = this.originSprite;
 
-            Vector2 originalPosition = getCurrentPosition(starttime);
-
-            if (duration == 0)
+            if (starttime == endtime)
             {
-                receptor.MoveX(starttime, originalPosition.X + value);
+                receptor.ScaleVec(starttime, newScale);
             }
             else
             {
-                receptor.MoveX(ease, starttime, starttime + duration, originalPosition.X, originalPosition.X + value);
+                receptor.ScaleVec(ease, starttime, endtime, ScaleAt(starttime), newScale);
             }
 
         }
 
-        public void MoveOriginRelativeY(double starttime, double value, OsbEasing ease, double duration)
-        {
-            OsbSprite receptor = this.originSprite;
-
-            Vector2 originalPosition = getCurrentPosition(starttime);
-
-            if (duration == 0)
-            {
-                receptor.MoveY(starttime, originalPosition.Y + value);
-            }
-            else
-            {
-                receptor.MoveY(ease, starttime, starttime + duration, originalPosition.Y, originalPosition.Y + value);
-            }
-
-        }
-
-        public void ScaleReceptor(double starttime, Vector2 newPosition, OsbEasing ease, double duration)
-        {
-            OsbSprite receptor = this.originSprite;
-
-            if (duration == 0)
-            {
-                receptor.ScaleVec(starttime, newPosition);
-            }
-            else
-            {
-                receptor.ScaleVec(ease, starttime, starttime + duration, getCurrentScale(starttime), newPosition);
-            }
-
-        }
-
-        public void RotateReceptor(double starttime, double rotation, OsbEasing ease, double duration)
+        public void RotateReceptor(OsbEasing ease, double starttime, double endtime, double rotation)
         {
             OsbSprite receptor = this.originSprite;
 
             var newRotation = this.rotation + rotation;
 
-            if (duration == 0)
+            if (starttime == endtime)
             {
                 receptor.Rotate(starttime, newRotation);
             }
             else
             {
-                receptor.Rotate(ease, starttime, starttime + duration, getCurrentRotaion(starttime), newRotation);
+                receptor.Rotate(ease, starttime, endtime, RotationAt(starttime), newRotation);
             }
 
             this.rotation = newRotation;
 
         }
 
-        public void PivotReceptor(double starttime, double rotation, OsbEasing ease, double duration, int stepcount, Vector2 center)
+        public void PivotOrigin(OsbEasing ease, double starttime, double endtime, double rotation, Vector2 center)
         {
+            Vector2 point = PositionAt(starttime);
 
-            this.RotateReceptor(starttime, rotation, ease, duration);
+            double duration = Math.Max(endtime - starttime - 1, 1);
+            double endRadians = rotation; // Total rotation in radians
 
-            Vector2 point = originSprite.PositionAt(starttime);
+            Vector2 currentPosition = point;
+            double currentTime = starttime;
 
-            double totalTime = starttime + duration; // Total duration in milliseconds
-            double stepTime = duration / stepcount; // Step duration in milliseconds
-
-            double endRadians = rotation; // Set the desired end radians here, 2*PI radians is a full circle
-            double rotationPerIteration = endRadians / (stepcount - 1); // Rotation per iteration
-
-            for (int i = 0; i < stepcount; i++)
+            while (currentTime < endtime - 1)
             {
-                var currentTime = starttime + stepTime * i;
+                currentTime += deltaIncrement;
+                double progress = Math.Max(currentTime - starttime, 1) / duration; // Calculate progress as a ratio
 
-                Vector2 rotatedPoint = PivotPoint(point, center, rotationPerIteration * i);
-                this.MoveOrigin(currentTime, rotatedPoint, ease, stepTime);
+                // Adjust the rotation based on progress and easing
+                double easedProgress = ease.Ease(progress); // Assuming ease.Ease() applies the easing to the progress
+                double currentRotation = endRadians * easedProgress; // Total rotation adjusted by eased progress
+
+                Vector2 rotatedPoint = Utility.PivotPoint(point, center, currentRotation);
+
+                Vector2 relativeMovement = rotatedPoint - currentPosition;
+                Vector2 absoluteMovement = rotatedPoint - point;
+
+                MoveOriginRelative(ease, currentTime, currentTime, relativeMovement, absoluteMovement);
+
+                currentPosition = rotatedPoint;
             }
         }
-
-        public void PivotAndRescaleReceptor(double starttime, double rotation, OsbEasing ease, double duration, int stepcount, Vector2 center, double targetDistance)
-        {
-            Vector2 initialPoint = originSprite.PositionAt(starttime);
-
-            double stepTime = duration / stepcount;
-            double rotationPerIteration = rotation / (stepcount - 1);
-
-            // Calculate initial distance
-            double initialDistance = (initialPoint - center).Length;
-
-            for (int i = 0; i < stepcount; i++)
-            {
-                var currentTime = starttime + stepTime * i;
-
-                // Rotate the point
-                Vector2 rotatedPoint = Utility.PivotPoint(initialPoint, center, rotationPerIteration * i);
-
-                // Get the direction in which we're moving (based on rotation around the center).
-                Vector2 directionFromCenter = rotatedPoint - center;
-                directionFromCenter.Normalize(); // Normalize to get a unit vector
-
-                // Interpolate between initialDistance and targetDistance based on the progress
-                double desiredDistance = initialDistance + (targetDistance - initialDistance) * ((double)i / stepcount);
-
-                // Compute the new position based on the desired distance
-                Vector2 newPoint = center + directionFromCenter * (float)desiredDistance;
-
-                MoveOrigin(currentTime, newPoint, ease, stepTime);
-            }
-        }
-
 
         public static Vector2 PivotPoint(Vector2 point, Vector2 center, double radians)
         {
@@ -223,23 +214,174 @@ namespace StorybrewScripts
             return rotatedPoint + center;
         }
 
-        public Vector2 getCurrentScale(double currentTime)
+        public Vector2 ScaleAt(double currentTime)
         {
-            CommandScale scale = this.originSprite.ScaleAt(currentTime);
-            return new Vector2(scale.X, scale.Y);
+            return originSprite.ScaleAt(currentTime);
         }
 
-        public Vector2 getCurrentPosition(double currentTime)
+        public float RotationAt(double currentTIme)
         {
-            CommandPosition position = this.originSprite.PositionAt(currentTime);
-            return new Vector2(position.X, position.Y);
+            return originSprite.RotationAt(currentTIme);
         }
 
-        public float getCurrentRotaion(double currentTIme)
+        private void AddXValue(double time, float value, float progressed, bool absolute = false)
         {
-            return this.originSprite.RotationAt(currentTIme);
+            if (positionX.ContainsKey(time))
+            {
+
+                if (absolute)
+                    positionX[time] = value;
+                else
+                {
+                    positionX[time] += progressed;
+                }
+
+            }
+            else
+            {
+
+                float lastValue = getLastX(time);
+
+                if (absolute)
+                    positionX.Add(time, value);
+                else
+                    positionX.Add(time, lastValue + value);
+
+            }
         }
 
 
+
+        private void AddYValue(double time, float value, float progressed, bool absolute = false)
+        {
+            if (positionY.ContainsKey(time))
+            {
+
+                if (absolute)
+                    positionY[time] = value;
+                else
+                {
+                    positionY[time] += progressed;
+                }
+
+            }
+            else
+            {
+
+                float lastValue = getLastY(time);
+
+                if (absolute)
+                    positionY.Add(time, value);
+                else
+                    positionY.Add(time, lastValue + value);
+
+            }
+
+        }
+
+        private float getLastX(double currentTime)
+        {
+            // Get all keys up to the current time, not including the current time
+            var earlierKeys = positionX.Keys.Where(t => t < currentTime).ToList();
+
+            // If there are any earlier keys, get the value of the largest (most recent) one
+            if (earlierKeys.Any())
+            {
+                double latestKey = earlierKeys.Max();
+                return positionX[latestKey];
+            }
+            else
+            {
+                // If there are no earlier keys, return a default value (e.g., 0)
+                return 0;
+            }
+        }
+
+
+
+
+        private float getLastY(double currentTime)
+        {
+            // Filter the keys to find those that are smaller than the current time
+            var smallerKeys = positionY.Keys.Where(t => t < currentTime);
+
+            // If there are any keys that meet the condition, return the largest of them
+            if (smallerKeys.Any())
+            {
+                return positionY[smallerKeys.Max()];
+            }
+            else
+            {
+                // If there are no keys smaller than the current time, return null or handle as needed
+                return 0; // or you could throw an exception or return a default value
+            }
+        }
+
+        private void easeProgressAbsolute(OsbEasing ease, double start, double end, Vector2 startPos, Vector2 endPos)
+        {
+
+
+            double duration = Math.Max(end - start, 0); // Ensure non-negative duration
+            double deltaTime = 0;
+            Vector2 lastPos = startPos; // Keep track of the last position to calculate the delta
+
+            double progress = 0;
+            do
+            {
+                deltaTime += deltaIncrement; // Increment time by deltaIncrement
+                progress = deltaTime / duration; // Normalized time [0, 1]
+                progress = Math.Min(progress, 1);       // Clamp progress to 1 to avoid overshooting
+
+                float t = (float)ease.Ease(progress);   // Apply easing function
+
+                Vector2 newPos = Vector2.Lerp(startPos, endPos, t); // Interpolated position
+                Vector2 movement = newPos - lastPos;               // Delta movement
+
+                // Apply the delta movement
+                AddXValue(start + deltaTime, movement.X, newPos.X);
+                AddYValue(start + deltaTime, movement.Y, newPos.Y);
+
+
+                lastPos = newPos;   // Update lastPos for the next iteration
+            } while (progress < 1);
+
+        }
+
+        private void easeProgressRelative(OsbEasing ease, double start, double end, Vector2 offset)
+        {
+            Vector2 startPos = new Vector2(0, 0); // Assuming starting at origin; replace with actual start if different
+            Vector2 endPos = startPos + offset;   // The final desired position
+
+            double duration = Math.Max(end - start, 0); // Ensure non-negative duration
+            double deltaTime = 0;
+            Vector2 lastPos = startPos; // Keep track of the last position to calculate the delta
+
+            double progress = 0;
+            do
+            {
+                deltaTime += deltaIncrement; // Increment time by deltaIncrement
+                progress = deltaTime / duration; // Normalized time [0, 1]
+                progress = Math.Min(progress, 1);       // Clamp progress to 1 to avoid overshooting
+
+                float t = (float)ease.Ease(progress);   // Apply easing function
+
+                Vector2 newPos = Vector2.Lerp(startPos, endPos, t); // Interpolated position
+                Vector2 movement = newPos - lastPos;               // Delta movement
+
+                // Apply the delta movement
+                AddXValue(start + deltaTime, movement.X, newPos.X);
+                AddYValue(start + deltaTime, movement.Y, newPos.Y);
+
+
+                lastPos = newPos;   // Update lastPos for the next iteration
+            } while (progress < 1);
+
+        }
+
+
+        public Vector2 PositionAt(double time)
+        {
+            return new Vector2(getLastX(time), getLastY(time));
+        }
     }
 }

--- a/PlayField/Column/NoteOrigin.cs
+++ b/PlayField/Column/NoteOrigin.cs
@@ -18,8 +18,8 @@ namespace StorybrewScripts
         public StoryboardLayer layer;
         public OsbSprite originSprite;
 
-        public Dictionary<double, float> positionX = new Dictionary<double, float>();
-        public Dictionary<double, float> positionY = new Dictionary<double, float>();
+        public SortedDictionary<double, float> positionX = new SortedDictionary<double, float>();
+        public SortedDictionary<double, float> positionY = new SortedDictionary<double, float>();
 
         public double bpmOffset;
         public double bpm;
@@ -173,13 +173,13 @@ namespace StorybrewScripts
         {
             Vector2 point = PositionAt(starttime);
 
-            double duration = Math.Max(endtime - starttime - 1, 1);
+            double duration = Math.Max(endtime - starttime, 1);
             double endRadians = rotation; // Total rotation in radians
 
             Vector2 currentPosition = point;
             double currentTime = starttime;
 
-            while (currentTime < endtime - 1)
+            while (currentTime <= endtime)
             {
                 currentTime += deltaIncrement;
                 double progress = Math.Max(currentTime - starttime, 1) / duration; // Calculate progress as a ratio
@@ -281,41 +281,63 @@ namespace StorybrewScripts
 
         private float getLastX(double currentTime)
         {
-            // Get all keys up to the current time, not including the current time
-            var earlierKeys = positionX.Keys.Where(t => t < currentTime).ToList();
+            if (positionX.Count == 0)
+            {
+                return 0; // Or your default value
+            }
 
-            // If there are any earlier keys, get the value of the largest (most recent) one
-            if (earlierKeys.Any())
+            var keys = positionX.Keys.ToList();
+            int left = 0;
+            int right = keys.Count - 1;
+            double lastKey = -1;
+
+            while (left <= right)
             {
-                double latestKey = earlierKeys.Max();
-                return positionX[latestKey];
+                int mid = left + (right - left) / 2;
+                if (keys[mid] < currentTime)
+                {
+                    lastKey = keys[mid];
+                    left = mid + 1;
+                }
+                else
+                {
+                    right = mid - 1;
+                }
             }
-            else
-            {
-                // If there are no earlier keys, return a default value (e.g., 0)
-                return 0;
-            }
+
+            return lastKey != -1 ? positionX[lastKey] : 0;
         }
-
-
 
 
         private float getLastY(double currentTime)
         {
-            // Filter the keys to find those that are smaller than the current time
-            var smallerKeys = positionY.Keys.Where(t => t < currentTime);
+            if (positionY.Count == 0)
+            {
+                return 0; // Or your default value
+            }
 
-            // If there are any keys that meet the condition, return the largest of them
-            if (smallerKeys.Any())
+            var keys = positionY.Keys.ToList();
+            int left = 0;
+            int right = keys.Count - 1;
+            double lastKey = -1;
+
+            while (left <= right)
             {
-                return positionY[smallerKeys.Max()];
+                int mid = left + (right - left) / 2;
+                if (keys[mid] < currentTime)
+                {
+                    lastKey = keys[mid];
+                    left = mid + 1;
+                }
+                else
+                {
+                    right = mid - 1;
+                }
             }
-            else
-            {
-                // If there are no keys smaller than the current time, return null or handle as needed
-                return 0; // or you could throw an exception or return a default value
-            }
+
+            return lastKey != -1 ? positionY[lastKey] : 0;
         }
+
 
         private void easeProgressAbsolute(OsbEasing ease, double start, double end, Vector2 startPos, Vector2 endPos)
         {

--- a/PlayField/Column/Receptor.cs
+++ b/PlayField/Column/Receptor.cs
@@ -24,48 +24,48 @@ namespace StorybrewScripts
         public string receptorSpritePath = "";
         public Vector2 position = new Vector2(0, 0);
         public StoryboardLayer layer;
-        public OsbSprite receptorSprite;
         public OsbSprite renderedSprite;
-        public Operation currentOperation;
         public OsbSprite debug;
         public string appliedTransformation = "";
-        List<Operation> operationLog = new List<Operation>();
+
+        public Dictionary<double, float> positionX = new Dictionary<double, float>();
+        public Dictionary<double, float> positionY = new Dictionary<double, float>();
 
         // Rotation in radiants
         public double rotation = 0f;
         public double startRotation = 0f;
         public ColumnType columnType;
-
         public double bpmOffset;
         public double bpm;
+        public double deltaIncrement = 1;
 
-        public KeyframedValue<Vector2> movmenetKeyFrames = new KeyframedValue<Vector2>(InterpolatingFunctions.Vector2);
-
-        public Receptor(String receptorSpritePath, double rotation, StoryboardLayer layer, CommandScale scale, double starttime, ColumnType type)
+        public Receptor(String receptorSpritePath, double rotation, StoryboardLayer layer, CommandScale scale, double starttime, ColumnType type, double delta)
         {
 
-            OsbSprite receptor = layer.CreateSprite("sb/transparent.png", OsbOrigin.Centre);
+            this.deltaIncrement = delta;
+
             OsbSprite receptorSprite = layer.CreateSprite(receptorSpritePath, OsbOrigin.Centre);
 
-            movmenetKeyFrames.Add(starttime, receptor.PositionAt(starttime));
+            positionX.Add(0, 0);
+            positionY.Add(0, 0);
 
             switch (type)
             {
                 case ColumnType.one:
-                    receptor.Rotate(starttime - 1, 1 * Math.PI / 2);
+                    receptorSprite.Rotate(starttime - 1, 1 * Math.PI / 2);
                     break;
                 case ColumnType.two:
-                    receptor.Rotate(starttime - 1, 0 * Math.PI / 2);
+                    receptorSprite.Rotate(starttime - 1, 0 * Math.PI / 2);
                     break;
                 case ColumnType.three:
-                    receptor.Rotate(starttime - 1, 2 * Math.PI / 2);
+                    receptorSprite.Rotate(starttime - 1, 2 * Math.PI / 2);
                     break;
                 case ColumnType.four:
-                    receptor.Rotate(starttime - 1, 3 * Math.PI / 2);
+                    receptorSprite.Rotate(starttime - 1, 3 * Math.PI / 2);
                     break;
             }
 
-            receptor.ScaleVec(starttime, scale);
+            receptorSprite.ScaleVec(starttime, scale);
 
             this.columnType = type;
             this.receptorSpritePath = receptorSpritePath;
@@ -73,16 +73,18 @@ namespace StorybrewScripts
             this.rotation = rotation;
             this.startRotation = rotation;
             this.layer = layer;
-            this.receptorSprite = receptor;
 
         }
 
-        public Receptor(String receptorSpritePath, double rotation, StoryboardLayer layer, Vector2 position, ColumnType type)
+        public Receptor(string receptorSpritePath, double rotation, StoryboardLayer layer, Vector2 position, ColumnType type, double delta)
         {
             OsbSprite receptor = layer.CreateSprite("sb/transparent.png", OsbOrigin.Centre);
             OsbSprite receptorSprite = layer.CreateSprite(receptorSpritePath, OsbOrigin.Centre);
 
-            movmenetKeyFrames.Add(0, position);
+            this.deltaIncrement = delta;
+
+            positionX.Add(0, 0);
+            positionY.Add(0, 0);
 
             switch (type)
             {
@@ -105,230 +107,180 @@ namespace StorybrewScripts
             this.renderedSprite = receptorSprite;
             this.rotation = rotation;
             this.layer = layer;
-            this.receptorSprite = receptor;
             this.position = position;
 
         }
 
-        public void MoveReceptor(double starttime, Vector2 newPosition, OsbEasing ease, double duration)
+        // Absolute Movements overwrite any and all relative movements that might have existed before them hence why they are absolute!
+        public void MoveReceptorAbsolute(double starttime, Vector2 endPos)
         {
-            OsbSprite receptor = this.receptorSprite;
 
-            double endtime = starttime + duration;
-
-            Vector2 originalPostion = getCurrentPosition(starttime);
-
-            if (duration == 0)
-            {
-                receptor.Move(starttime, newPosition);
-            }
-            else
-            {
-                receptor.Move(ease, starttime, starttime + duration, originalPostion, newPosition);
-            }
-
-        }
-
-        public void MoveReceptorEndTime(double starttime, Vector2 newPosition, OsbEasing ease, double endtime)
-        {
-            OsbSprite receptor = this.receptorSprite;
-
-            Vector2 originalPostion = getCurrentPosition(starttime);
-
-            if (endtime == starttime)
-            {
-                receptor.Move(endtime, newPosition);
-            }
-            else
-            {
-                receptor.Move(ease, starttime, endtime, originalPostion, newPosition);
-            }
-
-        }
-
-        public void MoveReceptorRelative(double starttime, Vector2 offset, OsbEasing ease, double duration)
-        {
-            OsbSprite receptor = this.receptorSprite;
-
-            Vector2 originalPostion = receptor.PositionAt(starttime);
-            Vector2 newPosition = Vector2.Add(originalPostion, offset);
-
-            if (duration == 0)
-            {
-                receptor.Move(starttime, newPosition);
-            }
-            else
-            {
-                receptor.Move(ease, starttime, starttime + duration, originalPostion, newPosition);
-            }
-
-        }
-
-        public void MoveReceptorRelativeX(double starttime, double value, OsbEasing ease, double duration)
-        {
-            OsbSprite receptor = this.receptorSprite;
-
-            Vector2 originalPostion = receptor.PositionAt(starttime);
-
-            if (duration == 0)
-            {
-                receptor.MoveX(starttime, originalPostion.X + value);
-            }
-            else
-            {
-                receptor.MoveX(ease, starttime, starttime + duration, originalPostion.X, originalPostion.X + value);
-            }
+            AddXValue(starttime, endPos.X, endPos.Y, true);
+            AddYValue(starttime, endPos.Y, endPos.Y, true);
 
 
         }
 
-        public void MoveReceptorRelativeY(double starttime, double value, OsbEasing ease, double duration)
+        // Absolute Movements overwrite any and all relative movements that might have existed before them hence why they are absolute!
+        public void MoveReceptorAbsolute(OsbEasing ease, double starttime, double endtime, Vector2 startPos, Vector2 endPos)
         {
-            OsbSprite receptor = this.receptorSprite;
 
-            Vector2 originalPostion = receptor.PositionAt(starttime);
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, endPos.X, endPos.X, true);
+                AddYValue(starttime, endPos.Y, endPos.Y, true);
+                return;
+            }
 
-            if (duration == 0)
-            {
-                receptor.MoveY(starttime, originalPostion.Y + value);
-            }
-            else
-            {
-                receptor.MoveY(ease, starttime, starttime + duration, originalPostion.Y, originalPostion.Y + value);
-            }
+            easeProgressAbsolute(ease, starttime, endtime, startPos, endPos);
 
         }
 
-        public void ScaleReceptor(double starttime, Vector2 newScale, OsbEasing ease, double duration)
+        public void MoveReceptorRelative(OsbEasing ease, double starttime, double endtime, Vector2 offset)
         {
-            OsbSprite receptor = this.receptorSprite;
 
-            Vector2 originalScale = getCurrentScale(starttime);
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, offset.X, offset.X);
+                AddYValue(starttime, offset.Y, offset.Y);
+                return;
+            }
 
-            if (duration == 0)
+            easeProgressRelative(ease, starttime, endtime, offset);
+
+        }
+
+        public void MoveReceptorRelative(OsbEasing ease, double starttime, double endtime, Vector2 offset, Vector2 absolute)
+        {
+
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, offset.X, absolute.X);
+                AddYValue(starttime, offset.Y, absolute.Y);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, offset);
+
+        }
+
+        public void MoveReceptorRelativeX(OsbEasing ease, double starttime, double endtime, float value)
+        {
+
+            if (starttime == endtime)
+            {
+                AddXValue(starttime, value, value);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, new Vector2(value, 0));
+
+        }
+
+        public void MoveReceptorRelativeY(OsbEasing ease, double starttime, double endtime, float value)
+        {
+            if (starttime == endtime)
+            {
+                AddYValue(starttime, value, value);
+                return;
+            }
+
+            easeProgressRelative(ease, starttime, endtime, new Vector2(0, value));
+
+        }
+
+        public void ScaleReceptor(OsbEasing ease, double starttime, double endtime, Vector2 newScale)
+        {
+            OsbSprite receptor = this.renderedSprite;
+
+            Vector2 originalScale = ScaleAt(starttime);
+
+            if (starttime == endtime)
             {
                 receptor.ScaleVec(starttime, newScale);
             }
             else
             {
-                receptor.ScaleVec(ease, starttime, starttime + duration, originalScale, newScale);
+                receptor.ScaleVec(ease, starttime, endtime, originalScale, newScale);
             }
         }
 
-        public void RotateReceptorAbsolute(double starttime, double duration, OsbEasing ease, double rotation)
+        public void RotateReceptorAbsolute(OsbEasing ease, double starttime, double endtime, double rotation)
         {
-            OsbSprite receptor = this.receptorSprite;
+            OsbSprite receptor = this.renderedSprite;
 
 
-            if (duration == 0)
+            if (starttime == endtime)
             {
                 receptor.Rotate(starttime, rotation);
             }
             else
             {
-                receptor.Rotate(ease, starttime, starttime + duration, getCurrentRotaion(starttime), rotation);
+                receptor.Rotate(ease, starttime, endtime, RotationAt(starttime), rotation);
             }
 
             this.rotation = rotation;
 
         }
 
-        public void RotateReceptor(double starttime, double duration, OsbEasing ease, double rotation)
+        public void RotateReceptor(OsbEasing ease, double starttime, double endtime, double rotation)
         {
-            OsbSprite receptor = this.receptorSprite;
+            OsbSprite receptor = this.renderedSprite;
+            var currentRot = RotationAt(starttime);
+            var newRotation = currentRot + rotation;
 
-            var newRotation = getCurrentRotaion(starttime) + rotation;
-
-            if (duration == 0)
+            if (starttime == endtime)
             {
                 receptor.Rotate(starttime, newRotation);
             }
             else
             {
-                receptor.Rotate(ease, starttime, starttime + duration, getCurrentRotaion(starttime), newRotation);
+                receptor.Rotate(ease, starttime, endtime, currentRot, newRotation);
             }
 
             this.rotation = newRotation;
 
         }
 
-        public void PivotReceptor(double starttime, double rotation, OsbEasing ease, double duration, int stepcount, Vector2 center)
+        public void PivotReceptor(OsbEasing ease, double starttime, double endtime, double rotation, Vector2 center)
         {
+            Vector2 point = PositionAt(starttime);
 
-            Vector2 point = receptorSprite.PositionAt(starttime);
+            double duration = Math.Max(endtime - starttime - 1, 1);
+            double endRadians = rotation; // Total rotation in radians
 
-            double totalTime = starttime + duration; // Total duration in milliseconds
-            double stepTime = duration / stepcount; // Step duration in milliseconds
+            Vector2 currentPosition = point;
+            double currentTime = starttime;
 
-            double endRadians = rotation; // Set the desired end radians here, 2*PI radians is a full circle
-            double rotationPerIteration = endRadians / (stepcount - 1); // Rotation per iteration
-
-            for (int i = 0; i < stepcount; i++)
+            while (currentTime < endtime - 1)
             {
-                var currentTime = starttime + stepTime * i;
+                currentTime += deltaIncrement;
+                double progress = Math.Max(currentTime - starttime, 1) / duration; // Calculate progress as a ratio
 
-                Vector2 rotatedPoint = Utility.PivotPoint(point, center, rotationPerIteration * i);
-                this.MoveReceptor(currentTime, rotatedPoint, ease, stepTime);
-            }
-        }
+                // Adjust the rotation based on progress and easing
+                double easedProgress = ease.Ease(progress); // Assuming ease.Ease() applies the easing to the progress
+                double currentRotation = endRadians * easedProgress; // Total rotation adjusted by eased progress
 
-        public void PivotAndRescaleReceptor(double starttime, double rotation, OsbEasing ease, double duration, int stepcount, Vector2 center, double targetDistance)
-        {
-            Vector2 initialPoint = receptorSprite.PositionAt(starttime);
+                Vector2 rotatedPoint = Utility.PivotPoint(point, center, currentRotation);
 
-            double stepTime = duration / stepcount;
-            double rotationPerIteration = rotation / (stepcount - 1);
+                Vector2 relativeMovement = rotatedPoint - currentPosition;
+                Vector2 absoluteMovement = rotatedPoint - point;
 
-            // Calculate initial distance
-            double initialDistance = (initialPoint - center).Length;
+                MoveReceptorRelative(ease, currentTime, currentTime, relativeMovement, absoluteMovement);
 
-            for (int i = 0; i < stepcount; i++)
-            {
-                var currentTime = starttime + stepTime * i;
-
-                // Rotate the point
-                Vector2 rotatedPoint = Utility.PivotPoint(initialPoint, center, rotationPerIteration * i);
-
-                // Get the direction in which we're moving (based on rotation around the center).
-                Vector2 directionFromCenter = rotatedPoint - center;
-                directionFromCenter.Normalize(); // Normalize to get a unit vector
-
-                // Interpolate between initialDistance and targetDistance based on the progress
-                double desiredDistance = initialDistance + (targetDistance - initialDistance) * ((double)i / stepcount);
-
-                // Compute the new position based on the desired distance
-                Vector2 newPoint = center + directionFromCenter * (float)desiredDistance;
-
-                MoveReceptor(currentTime, newPoint, ease, stepTime);
+                currentPosition = rotatedPoint;
             }
         }
 
 
-
-        public Vector2 getCurrentScale(double currentTime)
+        public Vector2 ScaleAt(double currentTime)
         {
-            CommandScale scale = this.receptorSprite.ScaleAt(currentTime);
-            return new Vector2(scale.X, scale.Y);
+            return renderedSprite.ScaleAt(currentTime);
         }
 
-        public Vector2 getCurrentPosition(double currentTime)
+        public float RotationAt(double currentTIme)
         {
-            Vector2 position = this.receptorSprite.PositionAt(currentTime);
-
-            return position;
-        }
-
-        public Vector2 getCurrentPositionForNotes(double currentTime)
-        {
-            Vector2 position = this.receptorSprite.PositionAt(currentTime);
-            Vector2 currentScale = getCurrentScale(currentTime);
-
-            return position;
-        }
-
-        public float getCurrentRotaion(double currentTIme)
-        {
-            return this.receptorSprite.RotationAt(currentTIme);
+            return this.renderedSprite.RotationAt(currentTIme);
         }
 
         public void Render(double starttime, double endtime)
@@ -374,8 +326,6 @@ namespace StorybrewScripts
                 adjustedTime += beatDuration;
             }
 
-            sprite.ScaleVec(starttime, receptorSprite.ScaleAt(starttime));
-
         }
 
         public void RenderTransformed(double starttime, double endtime, string reference)
@@ -389,44 +339,16 @@ namespace StorybrewScripts
             OsbSprite oldSprite = this.renderedSprite;
             this.appliedTransformation = reference;
             oldSprite.Fade(starttime, 0);
-            OsbSprite sprite = layer.CreateSprite(Path.Combine("sb", "transformation", reference, this.columnType.ToString(), "receptor", "receptor" + ".png"), OsbOrigin.Centre, receptorSprite.PositionAt(starttime));
+            OsbSprite sprite = layer.CreateSprite(Path.Combine("sb", "transformation", reference, this.columnType.ToString(), "receptor", "receptor" + ".png"), OsbOrigin.Centre, PositionAt(starttime));
 
             sprite.Rotate(starttime, 0);
-            sprite.ScaleVec(starttime, receptorSprite.ScaleAt(starttime));
+            sprite.ScaleVec(starttime, renderedSprite.ScaleAt(starttime));
             sprite.Fade(starttime, 1);
             sprite.Fade(endtime, 0);
 
             this.renderedSprite = sprite;
 
             // oldSprite = null;
-        }
-
-        public void addOperation(Operation operation)
-        {
-
-            operationLog.Add(operation);
-            operationLog.Sort((a, b) => a.starttime.CompareTo(b.starttime));
-
-        }
-
-        public List<Operation> executeOperations()
-        {
-            List<Operation> brokenUpOperations = Operation.ResolveOverlaps(operationLog);
-
-            brokenUpOperations.ForEach(op =>
-            {
-                switch (op.type)
-                {
-                    case OperationType.MOVE:
-                        receptorSprite.Move(op.easing, op.starttime, op.endtime, receptorSprite.PositionAt(op.starttime - 1), (CommandPosition)op.value);
-                        break;
-                    case OperationType.MOVERELATIVE:
-                        receptorSprite.Move(op.easing, op.starttime, op.endtime, receptorSprite.PositionAt(op.starttime), Vector2.Add(receptorSprite.PositionAt(op.starttime), (CommandPosition)op.value));
-                        break;
-                }
-            });
-
-            return brokenUpOperations;
         }
 
         public Color4 LerpColor(Color4 colorA, Color4 colorB, double t)
@@ -437,6 +359,165 @@ namespace StorybrewScripts
             byte a = (byte)(colorA.A + t * (colorB.A - colorA.A));
 
             return new Color4(r, g, b, a);
+        }
+
+        private void AddXValue(double time, float value, float progressed, bool absolute = false)
+        {
+            if (positionX.ContainsKey(time))
+            {
+
+                if (absolute)
+                    positionX[time] = value;
+                else
+                {
+                    positionX[time] += progressed;
+                }
+
+            }
+            else
+            {
+
+                float lastValue = getLastX(time);
+
+                if (absolute)
+                    positionX.Add(time, value);
+                else
+                    positionX.Add(time, lastValue + value);
+
+            }
+        }
+
+
+
+        private void AddYValue(double time, float value, float progressed, bool absolute = false)
+        {
+            if (positionY.ContainsKey(time))
+            {
+
+                if (absolute)
+                    positionY[time] = value;
+                else
+                {
+                    positionY[time] += progressed;
+                }
+
+            }
+            else
+            {
+
+                float lastValue = getLastY(time);
+
+                if (absolute)
+                    positionY.Add(time, value);
+                else
+                    positionY.Add(time, lastValue + value);
+
+            }
+
+        }
+
+        private float getLastX(double currentTime)
+        {
+            // Get all keys up to the current time, not including the current time
+            var earlierKeys = positionX.Keys.Where(t => t < currentTime).ToList();
+
+            // If there are any earlier keys, get the value of the largest (most recent) one
+            if (earlierKeys.Any())
+            {
+                double latestKey = earlierKeys.Max();
+                return positionX[latestKey];
+            }
+            else
+            {
+                // If there are no earlier keys, return a default value (e.g., 0)
+                return 0;
+            }
+        }
+
+
+
+
+        private float getLastY(double currentTime)
+        {
+            // Filter the keys to find those that are smaller than the current time
+            var smallerKeys = positionY.Keys.Where(t => t < currentTime);
+
+            // If there are any keys that meet the condition, return the largest of them
+            if (smallerKeys.Any())
+            {
+                return positionY[smallerKeys.Max()];
+            }
+            else
+            {
+                // If there are no keys smaller than the current time, return null or handle as needed
+                return 0; // or you could throw an exception or return a default value
+            }
+        }
+
+        private void easeProgressAbsolute(OsbEasing ease, double start, double end, Vector2 startPos, Vector2 endPos)
+        {
+
+            double duration = Math.Max(end - start, 0); // Ensure non-negative duration
+            double deltaTime = 0;
+            Vector2 lastPos = startPos; // Keep track of the last position to calculate the delta
+
+            double progress = 0;
+            do
+            {
+                deltaTime += deltaIncrement; // Increment time by deltaIncrement
+                progress = deltaTime / duration; // Normalized time [0, 1]
+                progress = Math.Min(progress, 1);       // Clamp progress to 1 to avoid overshooting
+
+                float t = (float)ease.Ease(progress);   // Apply easing function
+
+                Vector2 newPos = Vector2.Lerp(startPos, endPos, t); // Interpolated position
+                Vector2 movement = newPos - lastPos;               // Delta movement
+
+                // Apply the delta movement
+                AddXValue(start + deltaTime, movement.X, newPos.X);
+                AddYValue(start + deltaTime, movement.Y, newPos.Y);
+
+
+                lastPos = newPos;   // Update lastPos for the next iteration
+            } while (progress < 1);
+
+        }
+
+        private void easeProgressRelative(OsbEasing ease, double start, double end, Vector2 offset)
+        {
+            Vector2 startPos = new Vector2(0, 0); // Assuming starting at origin; replace with actual start if different
+            Vector2 endPos = startPos + offset;   // The final desired position
+
+            double duration = Math.Max(end - start, 0); // Ensure non-negative duration
+            double deltaTime = 0;
+            Vector2 lastPos = startPos; // Keep track of the last position to calculate the delta
+
+            double progress = 0;
+            do
+            {
+                deltaTime += deltaIncrement; // Increment time by deltaIncrement
+                progress = deltaTime / duration; // Normalized time [0, 1]
+                progress = Math.Min(progress, 1);       // Clamp progress to 1 to avoid overshooting
+
+                float t = (float)ease.Ease(progress);   // Apply easing function
+
+                Vector2 newPos = Vector2.Lerp(startPos, endPos, t); // Interpolated position
+                Vector2 movement = newPos - lastPos;               // Delta movement
+
+                // Apply the delta movement
+                AddXValue(start + deltaTime, movement.X, newPos.X);
+                AddYValue(start + deltaTime, movement.Y, newPos.Y);
+
+
+                lastPos = newPos;   // Update lastPos for the next iteration
+            } while (progress < 1);
+
+        }
+
+
+        public Vector2 PositionAt(double time)
+        {
+            return new Vector2(getLastX(time), getLastY(time));
         }
 
 

--- a/PlayField/Notes/Note.cs
+++ b/PlayField/Notes/Note.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenTK;
+using OpenTK.Graphics;
 using StorybrewCommon.Mapset;
 using StorybrewCommon.Storyboarding;
 
@@ -31,7 +32,7 @@ namespace StorybrewScripts
 
         static Random _random = new Random();
 
-        public Note(StoryboardLayer layer, OsuHitObject hitObject, Column column, double bpm, double offset, double msPerPart = 40)
+        public Note(StoryboardLayer layer, OsuHitObject hitObject, Column column, double bpm, double offset, bool isColored = false, double msPerPart = 40)
         {
 
             this.layer = layer;
@@ -102,31 +103,37 @@ namespace StorybrewScripts
 
             OsbSprite sprite = null;
 
-            switch (this.noteType)
+            if (isColored == false)
             {
-                case 1:
-                    sprite = layer.CreateSprite("sb/sprites/1.png");
-                    break;
-                case 2:
-                    sprite = layer.CreateSprite("sb/sprites/2.png");
-                    break;
-                case 3:
-                    sprite = layer.CreateSprite("sb/sprites/3.png");
-                    break;
-                case 4:
-                    sprite = layer.CreateSprite("sb/sprites/4.png");
-                    break;
-                case 12:
-                    sprite = layer.CreateSprite("sb/sprites/12.png");
-                    break;
-                case 16:
-                    sprite = layer.CreateSprite("sb/sprites/16.png");
-                    break;
-                default:
-                    this.noteType = 1;
-                    sprite = layer.CreateSprite("sb/sprites/1.png");
-                    break;
-
+                switch (this.noteType)
+                {
+                    case 1:
+                        sprite = layer.CreateSprite("sb/sprites/1.png");
+                        break;
+                    case 2:
+                        sprite = layer.CreateSprite("sb/sprites/2.png");
+                        break;
+                    case 3:
+                        sprite = layer.CreateSprite("sb/sprites/3.png");
+                        break;
+                    case 4:
+                        sprite = layer.CreateSprite("sb/sprites/4.png");
+                        break;
+                    case 12:
+                        sprite = layer.CreateSprite("sb/sprites/12.png");
+                        break;
+                    case 16:
+                        sprite = layer.CreateSprite("sb/sprites/16.png");
+                        break;
+                    default:
+                        this.noteType = 1;
+                        sprite = layer.CreateSprite("sb/sprites/1.png");
+                        break;
+                }
+            }
+            else
+            {
+                sprite = layer.CreateSprite("sb/sprites/arrow.png");
             }
 
             this.columnType = column.type;
@@ -182,8 +189,8 @@ namespace StorybrewScripts
             else
             {
                 note.Fade(starttime - 1, starttime + fadeInTime, 0, initialFade);
-                note.Fade(endtime + fadeOutTime + 1, 0);
-                renderEnd = endtime + fadeOutTime;
+                note.Fade(endtime, 0);
+                renderEnd = endtime;
             }
 
             renderStart = starttime;
@@ -352,7 +359,7 @@ namespace StorybrewScripts
             else
             {
                 note.Fade(starttime, starttime + fadeInTime, 0, 1);
-                note.Fade(endTime + fadeOutTime, 0);
+                note.Fade(endTime, 0);
             }
 
         }
@@ -505,16 +512,21 @@ namespace StorybrewScripts
             note.Rotate(easing, starttime, starttime + duration, getRotation(starttime), rotation);
         }
 
-        public void Scale(double starttime, double duration, OsbEasing easeing, Vector2 before, Vector2 after)
+        public void Scale(double starttime, double endtime, OsbEasing easeing, Vector2 before, Vector2 after)
         {
             OsbSprite note = this.noteSprite;
-            note.ScaleVec(easeing, starttime, starttime + duration, before, after);
+            note.ScaleVec(easeing, starttime, endtime, before, after);
         }
 
         public void ScaleDirect(double starttime, double duration, OsbEasing easeing, Vector2 before, Vector2 after)
         {
             OsbSprite note = this.noteSprite;
             note.ScaleVec(easeing, starttime, starttime + duration, before, after);
+        }
+
+        public void Color(double startime, Color4 color) {
+            OsbSprite note = this.noteSprite;
+            note.Color(starttime, color);
         }
 
         public double getRotation(double starttime)

--- a/PlayField/Playfield.cs
+++ b/PlayField/Playfield.cs
@@ -18,7 +18,7 @@ namespace StorybrewScripts
 
         // Default SB height / width
 
-        public double delta = 1;
+        public double delta = 2;
 
         private float absoluteWidth = 640f;
         public float width = 250f;
@@ -210,11 +210,16 @@ namespace StorybrewScripts
 
         public void Resize(OsbEasing easing, double starttime, double endtime, float width, float height)
         {
-            this.width = width;
-            this.height = height;
+
+            float wDiff = width;
+
+            if (width > 0)
+                wDiff = width * 2 - this.width;
+            else
+                wDiff = width - this.width * 2;
 
             float position = 0;
-            Vector2 left = calculatePlayFieldCenter(starttime) + new Vector2(width / 2, 0);
+            Vector2 left = calculatePlayFieldCenter(starttime) + new Vector2(wDiff / 2, 0);
 
             foreach (Column column in columns.Values)
             {
@@ -222,7 +227,7 @@ namespace StorybrewScripts
                 Receptor receptor = column.receptor;
                 NoteOrigin origin = column.origin;
 
-                float x = position + getColumnWidth() / 2;
+                float x = position + getColumnWidth(wDiff) / 2;
 
                 Vector2 receptorPos = receptor.PositionAt(starttime);
                 Vector2 originPos = origin.PositionAt(starttime);
@@ -252,9 +257,11 @@ namespace StorybrewScripts
                 receptor.MoveReceptorRelative(easing, starttime, endtime, newPosition);
                 origin.MoveOriginRelative(easing, starttime, endtime, newOpposit);
 
-                position += getColumnWidth();
+                position += getColumnWidth(wDiff);
             }
 
+            this.width = width;
+            this.height = height;
         }
 
         public void ScaleOrigin(OsbEasing easing, double starttime, double endtime, Vector2 scale, ColumnType type)
@@ -455,6 +462,62 @@ namespace StorybrewScripts
 
         }
 
+        public void MoveOriginAbsolute(double starttime, Vector2 to, ColumnType column)
+        {
+            if (column == ColumnType.all)
+            {
+                foreach (Column currentColumn in columns.Values)
+                {
+                    currentColumn.MoveOriginAbsoluite(starttime, to);
+                }
+            }
+            else
+            {
+                Column currentColumn = columns[column];
+
+                currentColumn.MoveOriginAbsoluite(starttime, to);
+            }
+
+        }
+
+        public void MoveOriginAbsolute(OsbEasing easing, double starttime, double endtime, Vector2 from, Vector2 to, ColumnType column)
+        {
+            if (column == ColumnType.all)
+            {
+                foreach (Column currentColumn in columns.Values)
+                {
+                    currentColumn.MoveOriginAbsoluite(easing, starttime, endtime, from, to);
+                }
+            }
+            else
+            {
+                Column currentColumn = columns[column];
+
+                currentColumn.MoveOriginAbsoluite(easing, starttime, endtime, from, to);
+            }
+
+        }
+
+        public void MoveOriginRelative(OsbEasing easing, double starttime, double endtime, Vector2 position, ColumnType column)
+        {
+            if (column == ColumnType.all)
+            {
+                foreach (Column currentColumn in columns.Values)
+                {
+
+                    currentColumn.MoveOriginRelative(easing, starttime, endtime, position);
+                }
+            }
+            else
+            {
+                Column currentColumn = columns[column];
+
+                currentColumn.MoveReceptorRelative(easing, starttime, endtime, position);
+
+            }
+
+        }
+
         public void RotateReceptorRelative(OsbEasing easing, double starttime, double endtime, double rotation, ColumnType column = ColumnType.all)
         {
             if (column == ColumnType.all)
@@ -475,6 +538,8 @@ namespace StorybrewScripts
             }
 
         }
+
+
 
         public void RotateReceptorAbsolute(OsbEasing easing, double starttime, double endtime, double rotation, ColumnType column = ColumnType.all)
         {
@@ -735,6 +800,16 @@ namespace StorybrewScripts
         }
 
         public float calculateOffset()
+        {
+            return (absoluteWidth - width) / 2;
+        }
+
+        public float getColumnWidth(float width)
+        {
+            return width / 4;
+        }
+
+        public float calculateOffset(float width)
         {
             return (absoluteWidth - width) / 2;
         }

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
 # Storybrew osu!Mania Modcharts
 ## How do i use this?
 
-# Soon to be documented here [https://notosu.sh/](https://notosu.sh/)
-
-Please give a smool link back to this if you use it for a beatmap!
-
-Requires normal [Storybrew](https://github.com/Damnae/storybrew)
-
 ### Initial Setup
 
 1. Download all files
 2. Drag and drop the Folders into your `/scriptLibrary` Directory
 3. Drag and drop `AForge.dll` and `AForge.Imaging.dll` into the Main Storybrew Directory
-4. Add `AForge.dll` and `AForge.Imaging.dll` to Assembly References *they are an Image editing library that are used for some Full Transformation effects*
-![settings](https://github.com/Tunnelbliick/maniaModCharts/assets/38663241/fe64d4a3-428a-4b8e-af5f-13aa3d8f6608)![reference](https://github.com/Tunnelbliick/maniaModCharts/assets/38663241/d49af5e5-d037-4ba9-8937-1c9ec54867f5)
+4. Add `AForge.dll` and `AForge.Imaging.dll` to Assembly References *they are an Image editing library that is used for some Full Transformation effekts*
 5. Initial setup complete!
 
 ### Setting up a Playfield
@@ -52,13 +45,13 @@ var recepotrBitmap = GetMapsetBitmap("sb/sprites/receiver.png"); // The receptor
 var receportWidth = recepotrBitmap.Width;
 
 Playfield field = new Playfield();
-field.initilizePlayField(receptors, notes, starttime, endtime, receportWidth, 60, 0);
-field.ScalePlayField(starttime, 0, OsbEasing.None, width, height);
+field.initilizePlayField(receptors, notes, startime, endtime, receportWidth, 60, 0);
+field.ScalePlayField(starttime + 1, 1, OsbEasing.None, width, height); // Its important that this gets executed AFTER the Playfield is initialized otherwise this will run into "overlapped commands" and break
 field.initializeNotes(Beatmap.HitObjects.ToList(), notes, bpm, offset, sliderAccuracy);
 
 DrawInstance draw = new DrawInstance(field, starttime, scrollSpeed, updatesPerSecond, OsbEasing.None, rotateNotesToFaceReceptor, fadeTime, fadeTime);
 
-// All effects have to be executed before calling the draw Function.
+// All effekts have to be executed before calling the draw Function.
 // Anything that is done after the draw Function call will not be rendered out.
 draw.drawNotesByOriginToReceptor(duration);
 ```

--- a/effects/EffectInfo.cs
+++ b/effects/EffectInfo.cs
@@ -12,6 +12,7 @@ namespace storyboard.scriptslibrary.maniaModCharts.effects
         public double duration { get; private set; }
         public EffectType effektType { get; private set; }
         public string reference { get; private set; }
+        public float value;
 
         public EffectInfo(double starttime, double endtime, EffectType type, string reference)
         {
@@ -20,6 +21,16 @@ namespace storyboard.scriptslibrary.maniaModCharts.effects
             this.duration = endtime - starttime;
             this.effektType = type;
             this.reference = reference;
+        }
+
+        public EffectInfo(double starttime, double endtime, EffectType type, string reference, float value)
+        {
+            this.starttime = starttime;
+            this.endtime = endtime;
+            this.duration = endtime - starttime;
+            this.effektType = type;
+            this.reference = reference;
+            this.value = value;
         }
     }
 }

--- a/effects/EffectType.cs
+++ b/effects/EffectType.cs
@@ -3,6 +3,8 @@ namespace storyboard.scriptslibrary.maniaModCharts.effects
     public enum EffectType
     {
         PlayfieldEffect,
-        TransformPlayfield3D
+        TransformPlayfield3D,
+        RenderPlayFieldUntil,
+        RenderPlayFieldFrom
     }
 }

--- a/effects/playfield/PlayFieldEffect.cs
+++ b/effects/playfield/PlayFieldEffect.cs
@@ -22,17 +22,19 @@ namespace StorybrewScripts
             this.field = field;
         }
 
+        // TODO Fix this
+        /*
         public double SwapColumn(ColumnType column1, ColumnType column2)
         {
 
             Column left = field.columns[column1];
             Column right = field.columns[column2];
 
-            Vector2 leftOrigin = left.getOriginPosition(this.starttime);
-            Vector2 leftReceptor = left.getReceptorPosition(this.starttime);
+            Vector2 leftOrigin = left.OriginPositionAt(this.starttime);
+            Vector2 leftReceptor = left.ReceptorPositionAt(this.starttime);
 
-            Vector2 rightOrigin = right.getOriginPosition(this.starttime);
-            Vector2 rightReceptor = right.getReceptorPosition(this.starttime);
+            Vector2 rightOrigin = right.OriginPositionAt(this.starttime);
+            Vector2 rightReceptor = right.ReceptorPositionAt(this.starttime);
 
             left.MoveColumn(starttime, duration, rightReceptor, rightOrigin, this.easing);
             right.MoveColumn(starttime, duration, leftReceptor, leftOrigin, this.easing);
@@ -45,8 +47,8 @@ namespace StorybrewScripts
 
             Column currentColumn = field.columns[column];
 
-            Vector2 originPosition = currentColumn.getOriginPosition(starttime);
-            Vector2 receptorPosition = currentColumn.getReceptorPosition(starttime);
+            Vector2 originPosition = currentColumn.OriginPositionAt(starttime);
+            Vector2 receptorPosition = currentColumn.ReceptorPositionAt(starttime);
 
             field.MoveOriginAbsolute(starttime, duration, easing, Vector2.Add(originPosition, relativeMovement), column);
             field.MoveReceptorAbsolute(starttime, duration, easing, Vector2.Add(receptorPosition, relativeMovement), column);
@@ -54,7 +56,10 @@ namespace StorybrewScripts
             return starttime + duration;
 
         }
+        */
 
+        // TODO
+        /*
         public void flipPlayField(float closeScale, float farScale)
         {
 
@@ -134,7 +139,7 @@ namespace StorybrewScripts
                 position += field.getColumnWidth();
             }
 
-        }
+        }*/
 
         public string TransformPlayfield3D(string relativePath, Vector2 topLeft, Vector2 topRight, Vector2 bottomRight, Vector2 bottomLeft)
         {

--- a/effects/playfield/PlayFieldEffect.cs
+++ b/effects/playfield/PlayFieldEffect.cs
@@ -141,6 +141,7 @@ namespace StorybrewScripts
 
         }*/
 
+        /*
         public string TransformPlayfield3D(string relativePath, Vector2 topLeft, Vector2 topRight, Vector2 bottomRight, Vector2 bottomLeft)
         {
 
@@ -219,6 +220,6 @@ namespace StorybrewScripts
                 }
             }
             return hash;
-        }
+        }*/
     }
 }

--- a/utility/CenterType.cs
+++ b/utility/CenterType.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StorybrewScripts
+{
+    public enum CenterType
+    {
+        receptor,
+        middle,
+        playfield
+    }
+}

--- a/utility/ImageManipulator.cs
+++ b/utility/ImageManipulator.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Drawing;
 using System.IO;
-using AForge.Imaging;
-using AForge.Imaging.Filters;
+//using AForge.Imaging;
+//using AForge.Imaging.Filters;
 using System.Collections.Generic;
-using AForge;
+//using AForge;
 using System.Linq;
 using System.Runtime.InteropServices;
 using OpenTK;
@@ -14,7 +14,7 @@ namespace StorybrewScripts
     public static class ImageManipulator
     {
 
-        public static Bitmap transformImage(Bitmap input, Vector2 topLeft, Vector2 topRight, Vector2 bottomRight, Vector2 bottomLeft)
+        /*public static Bitmap transformImage(Bitmap input, Vector2 topLeft, Vector2 topRight, Vector2 bottomRight, Vector2 bottomLeft)
         {
             Bitmap paddedImage = new Bitmap(input.Width * 2 + 100, input.Height * 2 + 100);
             using (Graphics g = Graphics.FromImage(paddedImage))
@@ -152,7 +152,7 @@ namespace StorybrewScripts
 
             return rotated;
 
-        }
+        }*/
 
 
     }

--- a/utility/Utility.cs
+++ b/utility/Utility.cs
@@ -30,6 +30,21 @@ namespace StorybrewScripts
             return amplitude * Math.Sin(2 * Math.PI * frequency * t);
         }
 
+        public static double CosWaveValue(double amplitude, double frequency, double t)
+        {
+            return amplitude * Math.Cos(2 * Math.PI * frequency * t);
+        }
+
+        public static double CosWaveValueWithPhase(double amplitude, double frequency, double t, double phase)
+        {
+            return amplitude * Math.Cos(2 * Math.PI * frequency * t + phase);
+        }
+
+        public static double TanValue(double amplitude, double frequency, double t)
+        {
+            return amplitude * Math.Tan(2 * Math.PI * frequency * t);
+        }
+
         public static double SineWaveValueWithPhase(double amplitude, double frequency, double time, double phase)
         {
             return amplitude * Math.Sin(2 * Math.PI * frequency * time + phase);
@@ -40,6 +55,56 @@ namespace StorybrewScripts
             float dx = firstPoint.X - secondPoint.X;
             float dy = firstPoint.Y - secondPoint.Y;
             return (float)Math.Sqrt(dx * dx + dy * dy) + 1f;
+        }
+
+        public static float SmoothAmplitudeByTime(double currentTime, double starttime, double endtime, double startValue, double endValue, float defaultValue = 0)
+        {
+
+            float smoothedAmplitude = 0;
+
+            // If within the first time range
+            if (currentTime >= starttime && currentTime <= endtime)
+            {
+                double start = starttime;
+                double end = endtime;  // Ending before the second segment starts
+
+                // Calculate progress in the range of [0, 1]
+                double progress = (currentTime - start) / (end - start);
+
+                // Use a starting amplitude and an ending amplitude to calculate the current amplitude
+                double startAmplitude = startValue;
+                double endAmplitude = endValue;
+                smoothedAmplitude = (float)(startAmplitude + progress * (endAmplitude - startAmplitude));
+            }
+            else
+            {
+                smoothedAmplitude = defaultValue;
+            }
+
+            return smoothedAmplitude;
+        }
+
+        public static float SmoothAmplitudeByProgress(float progress, float start, float end, double startValue, double endValue, float defaultValue = 0)
+        {
+
+            float smoothedAmplitude = 0f;
+
+            // If within the first time range
+            if (progress >= start && progress <= end)
+            {
+                double remappedProgress = (progress - start) / (end - start);
+
+                // Use a starting amplitude and an ending amplitude to calculate the current amplitude
+                double starScale = startValue;
+                double endScale = endValue;
+                smoothedAmplitude = (float)(starScale + remappedProgress * (endScale - starScale));
+            }
+            else
+            {
+                smoothedAmplitude = defaultValue;
+            }
+
+            return smoothedAmplitude;
         }
 
 


### PR DESCRIPTION
**FULL BREAKING CHANGES / BASICALLY A FULL RECODE OF CERTAIN PARTS**

- Overlapp resolve
 - Multiple commands will nolonger interrupt each other, instead every movement on receptors and origins is summed together and executed at rendertime, this is still semi work in progress but should make comming up with mods and actually creating them alot easier.
- Rework of setup
 - Streamlined the playfield initilization, and removed lots of unused parameters.
 - The Playfield initializer now creates the default position for the playfield with the default size, additionally the receptors are bound to a border box by default never allowed to exed 0 or 480 so that the receptors do not go offscreen if the height exeeds the canvas (480)
 - Additionally you can alter the Boundary box by increasing the padding on top and bottom that the receptors will respect, you can still move the receptors off screen using Move commands
- Reworking of Rotate Playfield
- Reworking of Zoom
- Removing uneseccary commands that with combined commands are nolonger needed
 - ZoomAndMove
 - ZoomMoveAndRotate